### PR TITLE
Removed Rails dependency

### DIFF
--- a/lib/money-rails.rb
+++ b/lib/money-rails.rb
@@ -8,4 +8,4 @@ end
 
 require "money-rails/version"
 require "money-rails/orms"
-require "money-rails/railtie"
+require "money-rails/railtie" if defined?(Rails)

--- a/lib/money-rails/railtie.rb
+++ b/lib/money-rails/railtie.rb
@@ -1,7 +1,9 @@
 module MoneyRails
   module Monetizable
-    ActiveSupport.on_load(:active_record) do
-      MoneyRails::Orms.extend_for :active_record
+    class Railtie < ::Rails::Railtie
+      initializer "moneyrails.initialize" do
+        MoneyRails::Orms.extend_for :active_record
+      end
     end
   end
 end


### PR DESCRIPTION
By adding this check you can still use the money-rails Gem even if you're not using all of Rails.
