### PR TITLE
Mongoid 2 Support

### DIFF
--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -11,7 +11,7 @@ module MoneyRails
       begin; require 'mongoid'; rescue LoadError; end
       if defined? ::Mongoid
         if ::Mongoid::VERSION =~ /^2(.*)/
-          # Mongoid 2.x stuff here
+          require 'money-rails/mongoid/two' # Loading the file is enough
         end
 
         if ::Mongoid::VERSION =~ /^3(.*)/

--- a/lib/money-rails/mongoid/two.rb
+++ b/lib/money-rails/mongoid/two.rb
@@ -1,0 +1,25 @@
+# Class name does not really matches the folder hierarchy, because
+# in order for (de)serialization to work, the class must be re-opened.
+# But this file brings mongoid 2.X compat., so...
+
+class Money
+  include ::Mongoid::Fields::Serializable
+
+  # Mongo friendly -> Money
+  def deserialize(object)
+    return nil if object.nil?
+
+    object = object.with_indifferent_access
+    ::Money.new object[:cents], object[:currency_iso]
+  end
+
+  # Money -> Mongo friendly
+  def serialize(object)
+    return nil unless object.is_a? Money
+
+    {
+      :cents        => object.cents,
+      :currency_iso => object.currency.iso_code
+    }
+  end
+end


### PR DESCRIPTION
This commit allows users to use `Money` as a field type for Mongoid 2.x. The following can be done :

``` ruby
class Priceable
  include Mongoid::Document

  field :price, type: Money
end

obj = Priceable.new
# => #<Priceable _id: 4fe865699671383656000001, _type: nil, price: nil>

obj.price
# => nil

obj.price = Money.new(100, 'EUR')
# => #<Money cents:100 currency:EUR>

obj.price
#=> #<Money cents:100 currency:EUR>

obj.save
# => true

obj
# => #<Priceable _id: 4fe865699671383656000001, _type: nil, price: {:cents=>100, :currency_iso=>"EUR"}>

obj.price
#=> #<Money cents:100 currency:EUR>
```

There is no test at the moment because I don't know how to setup the test chain for mongoid. So I leave this part to you, unless you can tell how to do it. :)
