### PR TITLE
Refactor instance currency implementation

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -21,10 +21,8 @@ module MoneyRails
               ":with_currency or :with_model_currency")
           end
 
-          # Optional table column which holds currency iso_codes
-          # It allows per row currency values
-          # Overrides default currency
-          currency_column_name = options[:with_model_currency] ||
+          # Optional accessor to be run on an instance to detect currency 
+          instance_currency_name = options[:with_model_currency] ||
             options[:model_currency] || "currency"
 
           # This attribute allows per column currency values
@@ -47,16 +45,11 @@ module MoneyRails
             name = subunit_name << "_money"
           end
 
-          has_currency_table_column = self.column_names.include? currency_column_name
-
-          raise(ArgumentError, ":with_currency should not be used with tables" \
-                  " which contain a column for currency values") if has_currency_table_column && field_currency_name
-
           # Include numericality validation if needed
           validates_numericality_of subunit_name, :allow_nil => options[:allow_nil] if MoneyRails.include_validations
 
           define_method name do
-            amount = read_attribute(subunit_name)
+            amount = send(subunit_name)
             attr_currency = send("currency_for_#{name}")
 
             # Dont create a new Money instance if the values haven't changed
@@ -71,30 +64,20 @@ module MoneyRails
 
           define_method "#{name}=" do |value|
             if options[:allow_nil] && value.blank?
-              write_attribute(subunit_name, nil)
-              write_attribute(currency_column_name, nil) if has_currency_table_column
-              instance_variable_set "@#{name}", nil
-              return
+              money = nil
+            else
+              money = value.is_a?(Money) ? value : value.to_money(send("currency_for_#{name}"))
             end
 
-            if has_currency_table_column
-              raise(ArgumentError, "Only Money objects are allowed for assignment") unless value.kind_of?(Money)
-              money = value
-              write_attribute(currency_column_name, money.currency.iso_code)
-            else
-              raise(ArgumentError, "Can't convert #{value.class} to Money") unless value.respond_to?(:to_money)
-              money = value.to_money(send("currency_for_#{name}"))
-            end
+            send("#{subunit_name}=", money.try(:cents))
+            send("#{instance_currency_name}=", money.try(:currency)) if self.respond_to?("#{instance_currency_name}=")
 
             instance_variable_set "@#{name}", money
-
-            write_attribute(subunit_name, money.cents)
           end
 
           define_method "currency_for_#{name}" do
-            row_currency = read_attribute(currency_column_name)
-            if has_currency_table_column && row_currency
-              Money::Currency.find(row_currency)
+            if self.respond_to?(instance_currency_name) && send(instance_currency_name).present? 
+              Money::Currency.find(send(instance_currency_name))
             elsif field_currency_name
               Money::Currency.find(field_currency_name)
             elsif self.class.respond_to?(:currency)

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -164,6 +164,14 @@ if defined? ActiveRecord
         @product.save.should be_true
         @product.optional_price.should be_nil
       end
+
+      context "for column with currency:" do
+        it "is overridden by instance currency" do
+          product = Product.create(:price_cents => 5320, :discount => 350, :bonus_cents => 320)
+          product.stub(:currency) { "EUR" }
+          product.bonus.currency_as_string.should == "EUR"
+        end
+      end
       
       context "for model with currency column:" do
         before :each do
@@ -201,9 +209,9 @@ if defined? ActiveRecord
           @transaction.amount.currency_as_string.should == "EUR"
         end
 
-        it "raises exception if a non Money object is assigned to the attribute" do
-          expect { @transaction.amount = "not a Money object" }.to raise_error(ArgumentError)
-          expect { @transaction.amount = 234 }.to raise_error(ArgumentError)
+        it "uses default currency if a non Money object is assigned to the attribute" do
+          @transaction.amount = 234
+          @transaction.amount.currency_as_string.should == "USD"
         end
 
       end


### PR DESCRIPTION
This change takes advantage of the removal of the limitations imposed by `composed_of` to re-implement instance currency so that it is 
1. Agnostic about implementation (you can use a column on the table, or just a method)
2. Compatible with field currency (so that if field currency is set but the instance currency returns a non-nil value, it overrides it)

This should be backwards compatible, it just won't error in the case where you try to use both instance and field currency at the same time.

I had to remove the use of read/write attribute to make this work, but they were not being properly used anyway (I think that actually they should really only be used to override AR attr accessor methods, not to invoke them).

It's also less code :)
