### PR TITLE
Add mongoid require statement

### DIFF
--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -8,7 +8,7 @@ module MoneyRails
       end
 
       # For Mongoid
-      begin; require 'mongoid'; rescue LoadError; end
+      begin; require 'mongoid'; require 'mongoid/version'; rescue LoadError; end
       if defined? ::Mongoid
         if ::Mongoid::VERSION =~ /^2(.*)/
           require 'money-rails/mongoid/two' # Loading the file is enough


### PR DESCRIPTION
Some Mongoid versions (including at least v2.4.1) do not `require 'mongoid/version'`, so that the constant Mongoid::VERSION cannot be inspected by the money-rails initializer. This pull request addresses this issue.

Is it desirable or even possible to add an automated test for this change?
