### PR TITLE
Fixed error when demongoize is called with an argument other than a hash

### DIFF
--- a/lib/money-rails/mongoid/three.rb
+++ b/lib/money-rails/mongoid/three.rb
@@ -13,9 +13,12 @@ class Money
     # Get the object as it was stored in the database, and instantiate
     # this custom class from it.
     def demongoize(object)
-      return nil if object.nil?
-      object.symbolize_keys!
-      ::Money.new(object[:cents], object[:currency_iso])
+      if object.is_a?(Hash) && object.has_key?(:cents)
+        object = object.symbolize_keys
+        ::Money.new(object[:cents], object[:currency_iso])
+      else
+        nil
+      end
     end
 
     # Takes any possible object and converts it to how it would be

--- a/spec/mongoid/three_spec.rb
+++ b/spec/mongoid/three_spec.rb
@@ -20,6 +20,10 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
         nil_priceable = Priceable.create(:price => nil)
         nil_priceable.price.should be_nil
       end
+      it 'returns nil if an unknown value was stored' do
+        zero_priceable = Priceable.create(:price => 0)
+        zero_priceable.price.should be_nil
+      end
     end
 
     context "evolve" do


### PR DESCRIPTION
If the database contained data that does not conform to the Money contract, an error is raised in the `demongoize` method. This pull request fixes the issue by explicitly checking for the type of the argument.
