### PR TITLE
Allow immediate subclasses to inherit monetized_attributes

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -50,7 +50,9 @@ module MoneyRails
           @monetized_attributes ||= {}
           @monetized_attributes[name.to_sym] = subunit_name
           class << self
-            attr_reader :monetized_attributes
+            def monetized_attributes
+              @monetized_attributes || superclass.monetized_attributes
+            end
           end unless respond_to? :monetized_attributes
 
           # Include numericality validation if needed

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -1,14 +1,19 @@
 require 'spec_helper'
 
+class Sub < Product; end
+
 if defined? ActiveRecord
   describe MoneyRails::ActiveRecord::Monetizable do
-
     describe "monetize" do
       before :each do
         @product = Product.create(:price_cents => 3000, :discount => 150,
                                   :bonus_cents => 200, :optional_price => 100,
                                   :sale_price_amount => 1200)
         @service = Service.create(:charge_cents => 2000, :discount_cents => 120)
+      end
+
+      it "should be inherited by subclasses" do
+        Sub.monetized_attributes.should == Product.monetized_attributes
       end
 
       it "attaches a Money object to model field" do


### PR DESCRIPTION
Currently monetized_attributes are not inherited (causing validations to fail)
