### PR TITLE
fixed error caused by ActiveSupport::HashWithIndifferentAccess

### DIFF
--- a/lib/money-rails/mongoid/three.rb
+++ b/lib/money-rails/mongoid/three.rb
@@ -27,7 +27,7 @@ class Money
       case
       when object.is_a?(Money) then object.mongoize
       when object.is_a?(Hash) then
-        object.symbolize_keys!
+        object.symbolize_keys! if object.respond_to?(:symbolize_keys!)
         ::Money.new(object[:cents], object[:currency_iso]).mongoize
       when object.respond_to?(:to_money) then
           object.to_money.mongoize

--- a/spec/mongoid/three_spec.rb
+++ b/spec/mongoid/three_spec.rb
@@ -6,6 +6,10 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
     let!(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
     let!(:priceable_from_num) { Priceable.create(:price => 1) }
     let!(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
+    let!(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
+    let!(:priceable_from_hash_with_indifferent_access) {
+      Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"}.with_indifferent_access)
+    }
 
     context "mongoize" do
       it "mongoizes correctly a Money object to a hash of cents and currency" do
@@ -21,6 +25,16 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
       it "mongoizes correctly a String object to a hash of cents and currency" do
         priceable_from_string.price.cents.should == 100
         priceable_from_string.price.currency.should == Money::Currency.find('EUR')
+      end
+
+      it "mongoizes correctly a hash of cents and currency" do
+        priceable_from_hash.price.cents.should == 100
+        priceable_from_hash.price.currency.should == Money::Currency.find('EUR')
+      end
+
+      it "mongoizes correctly a HashWithIndifferentAccess of cents and currency" do
+        priceable_from_hash_with_indifferent_access.price.cents.should == 100
+        priceable_from_hash_with_indifferent_access.price.currency.should == Money::Currency.find('EUR')
       end
     end
 


### PR DESCRIPTION
Hey, how is it going?

I got this error today in my rails up that uses mongoid v3:

``` ruby
Failure/Error: subject.add(variant: variant)
     NoMethodError:
       undefined method `symbolize_keys!' for {"cents"=>0, "currency_iso"=>"BRL"}:ActiveSupport::HashWithIndifferentAccess
```

It turns out the error was occurring in this method:

``` ruby
  def self.factory(product, variant = nil)
    variant ||= product.default_variant
    attributes = product.attributes.dup
    attributes.delete(:variants)
    new(attributes).tap do |ep|
      ep.id = product.id
      ep.build_variant(variant.attributes.dup)
      ep.variant.id = variant.id
      ep.images = product.images
      ep.original_product_id = product.id
      ep.original_variant_id = variant.id
    end
  end
```

Digging I found that the exception was raised here:

``` ruby
    def mongoize(object)
      case
      when object.is_a?(Money) then object.mongoize
      when object.is_a?(Hash) then
        object.symbolize_keys! if object.respond_to?(:symbolize_keys!)
        ::Money.new(object[:cents], object[:currency_iso]).mongoize
      when object.respond_to?(:to_money) then
          object.to_money.mongoize
      else object
      end
    end
```

I don't know if this is the right approach, but here it goes.

Let me know if you need any help.
