### PR TITLE
Fix validation for nothing-but-decimal-mark input

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -27,11 +27,12 @@ module MoneyRails
 
           decimal_pieces = raw_value.split(decimal_mark)
 
-          # check for numbers like 12.23.45
-          if decimal_pieces.length > 2
+          # check for numbers like '12.23.45' or '....'
+          unless [1, 2].include? decimal_pieces.length
             record.errors.add(attr, I18n.t('errors.messages.invalid_currency',
                                            { :thousands => thousands_separator,
                                              :decimal => decimal_mark }))
+            return
           end
 
           pieces = decimal_pieces[0].split(thousands_separator)

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -67,7 +67,7 @@ if defined? ActiveRecord
 
         @product.price = Money.new(320, "USD")
         @product.save.should be_true
-        
+
         @product.sale_price = "12.34"
         @product.sale_price_currency_code = 'EUR'
         @product.valid?.should be_true
@@ -75,6 +75,12 @@ if defined? ActiveRecord
 
       it "fails validation with the proper error message if money value is invalid decimal" do
         @product.price = "12.23.24"
+        @product.save.should be_false
+        @product.errors[:price].first.should match(/Must be a valid/)
+      end
+
+      it "fails validation with the proper error message if money value is nothing but periods" do
+        @product.price = "..."
         @product.save.should be_false
         @product.errors[:price].first.should match(/Must be a valid/)
       end
@@ -100,7 +106,7 @@ if defined? ActiveRecord
         Money.default_currency = Money::Currency.find('EUR')
         "12.00".to_money.should == Money.new(1200, :eur)
         transaction = Transaction.new(amount: "12.00", tax: "13.00")
-        transaction.amount_cents.should == 1200        
+        transaction.amount_cents.should == 1200
         transaction.valid?.should be_true
       end
 
@@ -109,7 +115,7 @@ if defined? ActiveRecord
         Money.default_currency = Money::Currency.find('EUR')
         "12,00".to_money.should == Money.new(1200, :eur)
         transaction = Transaction.new(amount: "12,00", tax: "13,00")
-        transaction.amount_cents.should == 1200        
+        transaction.amount_cents.should == 1200
         transaction.valid?.should be_true
       end
 
@@ -247,7 +253,7 @@ if defined? ActiveRecord
       end
 
       it "sets field to nil, in nil assignments if allow_nil is set" do
-        @product.optional_price = nil 
+        @product.optional_price = nil
         @product.save.should be_true
         @product.optional_price.should be_nil
       end


### PR DESCRIPTION
If you try to validate input that is nothing but decimal marks, it currently tries to call `split` on `nil` - this fixes the problem.
