### PR TITLE
Let default currency config accept currency without minor unit

### DIFF
--- a/lib/money-rails/configuration.rb
+++ b/lib/money-rails/configuration.rb
@@ -23,7 +23,7 @@ module MoneyRails
     def default_currency
       Money.default_currency
     end
-    
+
     # Set default currency of money library
     def default_currency=(currency_name)
       Money.default_currency = Money::Currency.new(currency_name)
@@ -37,7 +37,7 @@ module MoneyRails
     end
 
     def set_amount_column_for_default_currency!
-      amount_column.merge! postfix: "_#{default_currency.subunit.downcase.pluralize}"
+      amount_column.merge! postfix: "_#{default_currency.subunit.downcase.pluralize}" if default_currency.subunit
     end
 
     def set_currency_column_for_default_currency!

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -65,6 +65,19 @@ describe "configuration" do
       # Reset global setting
       MoneyRails.default_currency = old_currency
     end
-    
+
+    it "accepts default currency which doesn't have minor unit" do
+      old_currency = MoneyRails.default_currency
+
+      expect {
+        MoneyRails.default_currency = :jpy
+      }.to_not raise_error
+
+      MoneyRails.amount_column[:postfix].should == "_cents"
+
+      # Reset global setting
+      MoneyRails.default_currency = old_currency
+    end
+
   end
 end


### PR DESCRIPTION
Currency as Japanese Yen doesn't have a minor unit, see https://github.com/RubyMoney/money/pull/101

When setting such currency as default, the current implementation will raise NoMethodError since it tries to use the minor unit value.

This fixes that by checking if the unit value is present.
