### PR TITLE
greater_than_or_equal_to: 0 failing

### DIFF
--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -103,6 +103,10 @@ if defined? ActiveRecord
         @product.price_in_a_range = "10001"
         @product.valid?.should be_false
         @product.errors[:price_in_a_range].first.should match(/Must be greater than zero and less than \$10k/)
+
+        @product.price_in_a_range = "0"
+        @product.valid?.should be_false
+        @product.errors[:price_in_a_range].first.should match(/Must be greater than zero and less than \$10k/)
       end
 
       it "passes validation when amount contains spaces (99 999 999.99)" do


### PR DESCRIPTION
I am having a problem when my monetized attr is validating numericality greater_than_or_equal_to: 0. The validation is not been triggered when I set the value to 0.

I did a failing test, but am unable to figure out why it is happening.
