### PR TITLE
Pick instance currency from column defined by config.currency_column[:column_name], instead of defaulting to "currency"

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -21,9 +21,9 @@ module MoneyRails
               ":with_currency or :with_model_currency")
           end
 
-          # Optional accessor to be run on an instance to detect currency 
+          # Optional accessor to be run on an instance to detect currency
           instance_currency_name = options[:with_model_currency] ||
-            options[:model_currency] || "currency"
+            options[:model_currency] || MoneyRails::Configuration.currency_column[:column_name] || "currency"
           instance_currency_name = instance_currency_name.to_s
 
           # This attribute allows per column currency values
@@ -63,7 +63,7 @@ module MoneyRails
           #
           # All the options which are available for Rails numericality
           # validation, are also available for both types.
-          # E.g. 
+          # E.g.
           #   monetize :price_in_a_range_cents, :allow_nil => true,
           #     :subunit_numericality => {
           #       :greater_than_or_equal_to => 0,


### PR DESCRIPTION
This allows the currency of new AR instances to be picked from a column named something different than "currency". I need this because the currency colum in my database is called "currency_code", not "currency".

```
config.currency_column = { column_name: 'currency_code', ... }
```

I have a model defined like this:

```
# table job_types
# hourly_rate_cents
# currency_code - as specified in config.currency_column
class JobType
    monetize :hourly_rate_cents
end

job_type = JobType.new :currency_code => "EUR"
job_type.hourly_rate.currency.iso_code #=> "USD" -- This is wrong, because I've specified in config what the currency column should be
```

The current implementation does not use the currency_column configuration to decide which column needs to be inspected. This patch solves this particular problem.
