### PR TITLE
Changed ActiveRecord migration's amount column defaults (Re-created from #107 due to branch rename)

### DIFF
--- a/lib/generators/templates/money.rb
+++ b/lib/generators/templates/money.rb
@@ -29,10 +29,8 @@ MoneyRails.configure do |config|
   #                          postfix: '_cents',    # column name  postfix
   #                          column_name: nil,     # full column name (overrides prefix, postfix and accessor name)
   #                          type: :integer,       # column type
-  #                          present: true,        # column will be created
-  #                          null: false,          # other options will be treated as column options
-  #                          default: 0
-  #                        }
+  #                          present: true         # column will be created
+  #                        }                       # other options will be treated as column options
   #
   # config.currency_column = { prefix: '',
   #                            postfix: '_currency',

--- a/lib/money-rails/configuration.rb
+++ b/lib/money-rails/configuration.rb
@@ -62,7 +62,7 @@ module MoneyRails
 
     # Default ActiveRecord migration configuration values for columns
     mattr_accessor :amount_column
-    @@amount_column = { postfix: '_cents', type: :integer, null: false, default: 0, present: true }
+    @@amount_column = { postfix: '_cents', type: :integer, present: true }
 
     mattr_accessor :currency_column
     @@currency_column = { postfix: '_currency', type: :string, null: false, default: 'USD', present: true }

--- a/spec/active_record/migration_extensions/schema_statements_spec.rb
+++ b/spec/active_record/migration_extensions/schema_statements_spec.rb
@@ -36,8 +36,8 @@ if defined? ActiveRecord
         describe 'amount' do
           subject { Item.columns_hash['price_cents'] }
 
-          its (:default) { should eq 0 }
-          its (:null) { should be_false }
+          its (:default) { should be_nil }
+          its (:null) { should be_true }
           its (:type) { should eq :integer }
         end
 

--- a/spec/active_record/migration_extensions/table_spec.rb
+++ b/spec/active_record/migration_extensions/table_spec.rb
@@ -37,8 +37,8 @@ if defined? ActiveRecord
         describe 'amount' do
           subject { Item.columns_hash['price_cents'] }
 
-          its (:default) { should eq 0 }
-          its (:null) { should be_false }
+          its (:default) { should be_nil }
+          its (:null) { should be_true }
           its (:type) { should eq :integer }
         end
 


### PR DESCRIPTION
Re-creating pull request #107 here due to my renaming of the branch on my own repo. See #107 for details.
