### PR TITLE
Updated README with a migration example for allowing nills

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ monetized field, you can use the `:allow_nil` parameter like this:
 # in Product model
 monetize :optional_price_cents, :allow_nil => true
 
+# in Migration
+def change
+  add_money :products, :optional_price, amount: { null: true, default: nil }
+end
+
 # then blank assignments are permitted
 product.optional_price = nil
 product.save # returns without errors


### PR DESCRIPTION
If you use the migration helper for an allow_nil field, it takes a bit of digging to work out how to do it. The normal approach of `null: false` doesn't work.

I've added a working example to the section on allowing nils to make it a bit clearer:

``` ruby
add_money :products, :optional_price, amount: { null: true, default: nil }
```
