### PR TITLE
Added support for currency column with postfix _currency

### DIFF
--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -277,83 +277,83 @@ if defined? ActiveRecord
         @product.price = Money.new(2500, :USD)
         @product.save.should be_true
         @product.price.cents.should == 2500
-        @product.price.currency_as_string.should == "USD"
+        @product.price.should have_currency "USD"
       end
 
       it "assigns correctly Fixnum objects to the attribute" do
         @product.price = 25
         @product.save.should be_true
         @product.price.cents.should == 2500
-        @product.price.currency_as_string.should == "USD"
+        @product.price.should have_currency "USD"
 
         @service.discount = 2
         @service.save.should be_true
         @service.discount.cents.should == 200
-        @service.discount.currency_as_string.should == "EUR"
+        @service.discount.should have_currency "EUR"
       end
 
       it "assigns correctly String objects to the attribute" do
         @product.price = "25"
         @product.save.should be_true
         @product.price.cents.should == 2500
-        @product.price.currency_as_string.should == "USD"
+        @product.price.should have_currency "USD"
 
         @service.discount = "2"
         @service.save.should be_true
         @service.discount.cents.should == 200
-        @service.discount.currency_as_string.should == "EUR"
+        @service.discount.should have_currency "EUR"
       end
 
       it "overrides default, model currency with the value of :with_currency in fixnum assignments" do
         @product.bonus = 25
         @product.save.should be_true
         @product.bonus.cents.should == 2500
-        @product.bonus.currency_as_string.should == "GBP"
+        @product.bonus.should have_currency "GBP"
 
         @service.charge = 2
         @service.save.should be_true
         @service.charge.cents.should == 200
-        @service.charge.currency_as_string.should == "USD"
+        @service.charge.should have_currency "USD"
       end
 
       it "overrides default, model currency with the value of :with_currency in string assignments" do
         @product.bonus = "25"
         @product.save.should be_true
         @product.bonus.cents.should == 2500
-        @product.bonus.currency_as_string.should == "GBP"
+        @product.bonus.should have_currency "GBP"
 
         @service.charge = "2"
         @service.save.should be_true
         @service.charge.cents.should == 200
-        @service.charge.currency_as_string.should == "USD"
+        @service.charge.should have_currency "USD"
       end
 
       it "overrides default currency with model currency, in fixnum assignments" do
         @product.discount_value = 5
         @product.save.should be_true
         @product.discount_value.cents.should == 500
-        @product.discount_value.currency_as_string.should == "USD"
+        @product.discount_value.should have_currency "USD"
       end
 
       it "overrides default currency with model currency, in string assignments" do
         @product.discount_value = "5"
         @product.save.should be_true
         @product.discount_value.cents.should == 500
-        @product.discount_value.currency_as_string.should == "USD"
+        @product.discount_value.should have_currency "USD"
       end
 
       it "falls back to default currency, in fixnum assignments" do
         @service.discount = 5
         @service.save.should be_true
         @service.discount.cents.should == 500
-        @service.discount.currency_as_string.should == "EUR"
+        @service.discount.should have_currency "EUR"
       end
 
       it "falls back to default currency, in string assignments" do
         @service.discount = "5"
         @service.save.should be_true
         @service.discount.cents.should == 500
-        @service.discount.currency_as_string.should == "EUR"
+        @service.discount.should have_currency "EUR"
       end
 
       it "sets field to nil, in nil assignments if allow_nil is set" do
@@ -380,7 +380,7 @@ if defined? ActiveRecord
         it "is overridden by instance currency" do
           product = Product.create(:price_cents => 5320, :discount => 350, :bonus_cents => 320)
           product.stub(:currency) { "EUR" }
-          product.bonus.currency_as_string.should == "EUR"
+          product.bonus.should have_currency "EUR"
         end
       end
 
@@ -392,7 +392,7 @@ if defined? ActiveRecord
         it "is overridden by instance currency column" do
           product = Product.create(:sale_price_amount => 1234,
                                    :sale_price_currency_code => 'CAD')
-          product.sale_price.currency_as_string.should == 'CAD'
+          product.sale_price.should have_currency 'CAD'
         end
       end
 
@@ -442,12 +442,12 @@ if defined? ActiveRecord
           @transaction.amount = Money.new(2500, :eur)
           @transaction.save.should be_true
           @transaction.amount.cents.should == Money.new(2500, :eur).cents
-          @transaction.amount.currency_as_string.should == "EUR"
+          @transaction.amount.should have_currency "EUR"
         end
 
         it "uses default currency if a non Money object is assigned to the attribute" do
           @transaction.amount = 234
-          @transaction.amount.currency_as_string.should == "USD"
+          @transaction.amount.should have_currency "USD"
         end
 
         it "constructs the money object from the mapped method value" do
@@ -463,5 +463,31 @@ if defined? ActiveRecord
         DummyProduct.currency.should == Money::Currency.find(:gbp)
       end
     end
+
+    context "for column with model currency with default name:" do
+      it "has default currency if not specified" do
+        product = Product.create(:stock_value_cents => 1234)
+        product.stock_value.currency_as_string == 'USD'
+      end
+
+      it "is overridden by instance currency column" do
+        product = Product.create(:stock_value_cents => 1234,
+          :stock_value_currency => 'CAD')
+        product.stock_value.should have_currency 'CAD'
+      end
+
+      it "saves the currency when assigned" do
+        product = Product.create(:stock_value_cents => 1234,
+          :stock_value_currency => 'CAD')
+
+        product.stock_value = Money.new(1234, 'CHF')
+        product.save(validate: false)
+        product.reload
+
+        product.stock_value.should have_currency 'CHF'
+      end
+
+    end
   end
+
 end

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -3,7 +3,8 @@ class Product < ActiveRecord::Base
   attr_accessible :price_cents, :discount, :bonus_cents,
     :price, :discount_value, :bonus, :optional_price_cents, :optional_price,
     :sale_price, :sale_price_amount, :sale_price_currency_code,
-    :price_in_a_range_cents, :price_in_a_range
+    :price_in_a_range_cents, :price_in_a_range,
+    :stock_value_cents, :stock_value_currency, :stock_value
 
   # Use USD as model level currency
   register_currency :usd
@@ -34,5 +35,8 @@ class Product < ActiveRecord::Base
       :less_than_or_equal_to => 100,
       :message => "Must be greater than zero and less than $100"
     }
+
+  # Use money-rails macro with default currency column name
+  monetize :stock_value_cents
 
 end

--- a/spec/dummy/db/migrate/20130905171701_add_stock_value_to_product.rb
+++ b/spec/dummy/db/migrate/20130905171701_add_stock_value_to_product.rb
@@ -1,0 +1,5 @@
+class AddStockValueToProduct < ActiveRecord::Migration
+  def change
+    add_money :products, :stock_value
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130124023419) do
+ActiveRecord::Schema.define(:version => 20130905171701) do
 
   create_table "dummy_products", :force => true do |t|
     t.string   "currency"
@@ -26,13 +26,15 @@ ActiveRecord::Schema.define(:version => 20130124023419) do
   create_table "products", :force => true do |t|
     t.integer  "price_cents"
     t.integer  "discount"
-    t.datetime "created_at",                              :null => false
-    t.datetime "updated_at",                              :null => false
+    t.datetime "created_at",                                  :null => false
+    t.datetime "updated_at",                                  :null => false
     t.integer  "bonus_cents"
     t.integer  "optional_price_cents"
-    t.integer  "sale_price_amount",        :default => 0, :null => false
+    t.integer  "sale_price_amount",        :default => 0,     :null => false
     t.string   "sale_price_currency_code"
     t.integer  "price_in_a_range_cents"
+    t.integer  "stock_value_cents",        :default => 0,     :null => false
+    t.string   "stock_value_currency",     :default => "EUR", :null => false
   end
 
   create_table "services", :force => true do |t|

--- a/spec/support/have_currency.rb
+++ b/spec/support/have_currency.rb
@@ -1,0 +1,14 @@
+RSpec::Matchers.define :have_currency do |currency|
+  match do |money|
+    money.currency_as_string == currency
+  end
+
+  failure_message_for_should do |money|
+    "expected the money to have currency #{currency} but it was #{money.currency_as_string}"
+  end
+
+  failure_message_for_should_not do |money|
+    "expected the money to not have currency #{currency}"
+  end
+
+end


### PR DESCRIPTION
Added support for currency column created with money migration, changing `monetize` method and adding few specs.
I also refactored the test, adding a custom matcher, and the `monetize` method.

Every spec runs fine, but I had to use database-cleaner 1.0.1 because the current one (1.1.1) seems broken
