### PR TITLE
Fix mongoization of Money when using infinite_precision.

### DIFF
--- a/lib/money-rails/mongoid/money.rb
+++ b/lib/money-rails/mongoid/money.rb
@@ -3,8 +3,8 @@ class Money
   # Converts an object of this instance into a database friendly value.
   def mongoize
     {
-      :cents        => cents,
-      :currency_iso => currency.iso_code
+      :cents        => cents.mongoize,
+      :currency_iso => currency.iso_code.mongoize
     }
   end
 

--- a/lib/money-rails/mongoid/two.rb
+++ b/lib/money-rails/mongoid/two.rb
@@ -17,12 +17,12 @@ class Money
   def serialize(object)
     case
     when object.is_a?(Money)
-        {
-          :cents        => object.cents,
-          :currency_iso => object.currency.iso_code
-        }
+      {
+        :cents        => object.cents.is_a?(BigDecimal) ? object.cents.to_s : object.cents,
+        :currency_iso => object.currency.iso_code
+      }
     when object.respond_to?(:to_money)
-        serialize(object.to_money)
+      serialize(object.to_money)
     else nil
     end
   end

--- a/spec/mongoid/three_spec.rb
+++ b/spec/mongoid/three_spec.rb
@@ -10,6 +10,7 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
     let!(:priceable_from_hash_with_indifferent_access) {
       Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"}.with_indifferent_access)
     }
+    let(:priceable_with_infinite_precision) { Priceable.create(:price => Money.new(BigDecimal.new('100.1'), 'EUR')) }
     let(:priceable_with_hash_field) {
       Priceable.create(:price_hash => {
         :key1 => Money.new(100, "EUR"),
@@ -41,6 +42,21 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
       it "mongoizes correctly a HashWithIndifferentAccess of cents and currency" do
         priceable_from_hash_with_indifferent_access.price.cents.should == 100
         priceable_from_hash_with_indifferent_access.price.currency.should == Money::Currency.find('EUR')
+      end
+
+      context "infinite_precision = true" do
+        before do
+          Money.infinite_precision = true
+        end
+
+        after do
+          Money.infinite_precision = false
+        end
+
+        it "mongoizes correctly a Money object to a hash of cents and currency" do
+          priceable_with_infinite_precision.price.cents.should == BigDecimal.new('100.1')
+          priceable_with_infinite_precision.price.currency.should == Money::Currency.find('EUR')
+        end
       end
     end
 

--- a/spec/mongoid/two_spec.rb
+++ b/spec/mongoid/two_spec.rb
@@ -6,6 +6,7 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^2(.*)/
     let(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
     let(:priceable_from_num) { Priceable.create(:price => 1) }
     let(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
+    let(:priceable_with_infinite_precision) { Priceable.create(:price => Money.new(BigDecimal.new('100.1'), 'EUR')) }
 
     context "serialize" do
       it "serializes correctly a Money object to a hash of cents and currency" do
@@ -21,6 +22,21 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^2(.*)/
       it "mongoizes correctly a String object to a hash of cents and currency" do
         priceable_from_string.price.cents.should == 100
         priceable_from_string.price.currency.should == Money::Currency.find('EUR')
+      end
+
+      context "infinite_precision = true" do
+        before do
+          Money.infinite_precision = true
+        end
+
+        after do
+          Money.infinite_precision = false
+        end
+
+        it "mongoizes correctly a Money object to a hash of cents and currency" do
+          priceable_with_infinite_precision.price.cents.should == BigDecimal.new('100.1')
+          priceable_with_infinite_precision.price.currency.should == Money::Currency.find('EUR')
+        end
       end
     end
 


### PR DESCRIPTION
I ran into a problem using `Money.infinite_precision = true` in conjunction with Mongoid:

``` ruby
[36] pry(main)> Money.new(BigDecimal.new('12345.6')).mongoize
=> {:cents=>#<BigDecimal:7fe55a5723e8,'0.123456E5',18(18)>, :currency_iso=>"USD"}
```

When saving the model using this kind of money, Moped (or Mongoid) threw an error like this:

```
undefined method `__bson_dump__' for #<BigDecimal:7fe55a5723e8,'0.123456E5',18(18)>
```

It was caused by not mongoizing the values (particularly the cents) in the hash returned by `Money#mongoize`.

This PR fixes it and adds tests for it!
