### PR TITLE
Humanized_money_with_symbol: now accepts options that'll be passed on to...

### DIFF
--- a/lib/money-rails/helpers/action_view_extension.rb
+++ b/lib/money-rails/helpers/action_view_extension.rb
@@ -25,8 +25,8 @@ module MoneyRails
       end
     end
 
-    def humanized_money_with_symbol(value)
-      humanized_money(value, :symbol => true)
+    def humanized_money_with_symbol(value, options={})
+      humanized_money(value, options.merge(:symbol => true))
     end
 
     def money_without_cents(value, options={})


### PR DESCRIPTION
... .humanized_money

!!! I had trouble running the test suite (see: https://github.com/RubyMoney/money-rails/pull/130) - hopefully Travis will do this for me.

the reason I need to pass options to humanized_money_with_symbol is that we want to set the `no_cents_if_whole` option on a per-method-call basis.
