### PR TITLE
allow options hash as parameter to humanized_money_with_symbol

### DIFF
--- a/lib/money-rails/helpers/action_view_extension.rb
+++ b/lib/money-rails/helpers/action_view_extension.rb
@@ -25,8 +25,9 @@ module MoneyRails
       end
     end
 
-    def humanized_money_with_symbol(value)
-      humanized_money(value, :symbol => true)
+    def humanized_money_with_symbol(value, options={})
+      options[:symbol] ||= true
+      humanized_money(value, options)
     end
 
     def money_without_cents(value, options={})


### PR DESCRIPTION
You should be able to pass options to humanized_money_with_symbol as it is simply calling humanized_money which allows an options hash as the second parameter.
