### PR TITLE
Allow per-attribute disabling of validations

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -78,7 +78,7 @@ module MoneyRails
           #       :message => "Must be greater than zero and less than $100"
           #     }
           #
-          if MoneyRails.include_validations
+          if MoneyRails.include_validations && !options[:disable_validation]
 
             subunit_validation_options =
               unless options.has_key? :subunit_numericality

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -59,6 +59,11 @@ if defined? ActiveRecord
         product.save.should be_true
       end
 
+      it "skips numericality validation when disabled" do
+        product.invalid_price_cents = 'not_valid'
+        product.save.should be_true
+      end
+
       it "respects numericality validation when using update_attributes" do
         product.update_attributes(:price_cents => "some text").should be_false
         product.update_attributes(:price_cents => 2000).should be_true

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -3,7 +3,7 @@ class Product < ActiveRecord::Base
   attr_accessible :price_cents, :discount, :bonus_cents,
     :price, :discount_value, :bonus, :optional_price_cents, :optional_price,
     :sale_price, :sale_price_amount, :sale_price_currency_code,
-    :price_in_a_range_cents, :price_in_a_range
+    :price_in_a_range_cents, :price_in_a_range, :invalid_price_cents
 
   # Use USD as model level currency
   register_currency :usd
@@ -34,5 +34,8 @@ class Product < ActiveRecord::Base
       :less_than_or_equal_to => 100,
       :message => "Must be greater than zero and less than $100"
     }
+
+  attr_accessor :invalid_price_cents
+  monetize :invalid_price_cents, disable_validation: true
 
 end


### PR DESCRIPTION
I'd love some feedback on this. This feature allows disabling of validations on an individual attribute level, rather than only globally.

I have an app with several monetized columns that are aggregates. Example, in this `User` model:

```
has_many :accounts
monetize :balance_cents

def balance_cents
  accounts.sum(:balance_cents)
end
```

This has the unfortunate side effect of causing database calls to get the sums on every save. In this app, one model has 3 such aggregate columns causing a total of 6 unnecessary queries. I don't want to disable all validations, just the ones for this model since they are already validated upon input on the `Account` model. I've added a new `disable_validation` option like so:

```
monetize :balance_cents, disable_validation: true
```

Which then doesn't validate the column on this `User` model. The net effect is that the unnecessary database reads are eliminated.
