### PR TITLE
Fixed validation failing when there was a whitespace between the currency symbol and amount in a String price.

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -39,7 +39,7 @@ module MoneyRails
           symbol = I18n.t('number.currency.format.unit', default: currency.symbol)
 
           raw_value = raw_value.to_s.strip.gsub(symbol, "")
-          abs_raw_value = raw_value.gsub(/^-/, "")
+          abs_raw_value = raw_value.strip.gsub(/^-/, "")
 
           decimal_pieces = abs_raw_value.split(decimal_mark)
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -245,6 +245,11 @@ if defined? ActiveRecord
         product.save.should be_true
       end
 
+      it "passes validation if there is a whitespace between the currency symbol and amount" do
+        product.price = "$ 123,456.78"
+        product.save.should be_true
+      end
+
       it "respects numericality validation when using update_attributes on money attribute" do
         product.update_attributes(:price => "some text").should be_false
         product.update_attributes(:price => Money.new(320, 'USD')).should be_true

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -9,43 +9,43 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140110194016) do
+ActiveRecord::Schema.define(version: 20140110194016) do
 
-  create_table "dummy_products", :force => true do |t|
+  create_table "dummy_products", force: true do |t|
     t.string   "currency"
     t.integer  "price_cents"
-    t.datetime "created_at",  :null => false
-    t.datetime "updated_at",  :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "products", :force => true do |t|
+  create_table "products", force: true do |t|
     t.integer  "price_cents"
     t.integer  "discount"
-    t.datetime "created_at",                                   :null => false
-    t.datetime "updated_at",                                   :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "bonus_cents"
     t.integer  "optional_price_cents"
-    t.integer  "sale_price_amount",             :default => 0, :null => false
+    t.integer  "sale_price_amount",             default: 0, null: false
     t.string   "sale_price_currency_code"
     t.integer  "price_in_a_range_cents"
     t.integer  "validates_method_amount_cents"
   end
 
-  create_table "services", :force => true do |t|
+  create_table "services", force: true do |t|
     t.integer  "charge_cents"
     t.integer  "discount_cents"
-    t.datetime "created_at",     :null => false
-    t.datetime "updated_at",     :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "transactions", :force => true do |t|
+  create_table "transactions", force: true do |t|
     t.integer  "amount_cents"
     t.integer  "tax_cents"
     t.string   "currency"
-    t.datetime "created_at",   :null => false
-    t.datetime "updated_at",   :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end


### PR DESCRIPTION
The current validator was failing when we tried to use values like those:

product.price = "$ 123,456.89"
product.price = "R$ 123.456,78"

The problem was that abs_raw_value wasn't striping whitespaces after removing the currency symbol.

PS. That's like my first time sending a pull request, so I'm not sure if I did everything right.
