### PR TITLE
money-rails.gemspec: upgraded "money" and "monetize" dependencies.

### DIFF
--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_dependency "money",         "~> 6.1.0.beta1"
-  s.add_dependency "monetize",      "~> 0.1.4"
+  s.add_dependency "money",         "~> 6.1.1"
+  s.add_dependency "monetize",      "~> 0.2.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"
 


### PR DESCRIPTION
[https://github.com/RubyMoney/money-rails/issues/181](https://github.com/RubyMoney/money-rails/issues/181)
