### PR TITLE
Arbitrary format options

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,16 +318,24 @@ MoneyRails.configure do |config|
 
   # To set the default currency
   #
-  config.default_currency = :usd
+  # config.default_currency = :usd
 
-  # Add custom exchange rates
-  config.add_rate "USD", "CAD", 1.24515
-  config.add_rate "CAD", "USD", 0.803115
+  # Set default bank object
+  #
+  # Example:
+  # config.default_bank = EuCentralBank.new
+
+  # Add exchange rates to current money bank object.
+  # (The conversion rate refers to one direction only)
+  #
+  # Example:
+  # config.add_rate "USD", "CAD", 1.24515
+  # config.add_rate "CAD", "USD", 0.803115
 
   # To handle the inclusion of validations for monetized fields
   # The default value is true
   #
-  config.include_validations = true
+  # config.include_validations = true
 
   # Default ActiveRecord migration configuration values for columns:
   #
@@ -351,6 +359,7 @@ MoneyRails.configure do |config|
 
   # Register a custom currency
   #
+  # Example:
   # config.register_currency = {
   #   :priority            => 1,
   #   :iso_code            => "EU4",
@@ -376,15 +385,17 @@ MoneyRails.configure do |config|
   # 
   # set to BigDecimal::ROUND_HALF_EVEN by default
   # 
-  config.rounding_mode = BigDecimal::ROUND_HALF_UP 
+  # config.rounding_mode = BigDecimal::ROUND_HALF_UP
 
-  # Set money formatted output globally.
+  # Set default money format globally.
   # Default value is nil meaning "ignore this option".
-  # Options are nil, true, false.
+  # Example:
   #
-  # config.no_cents_if_whole = nil
-  # config.symbol = nil
-  # config.sign_before_symbol = nil
+  # config.default_format = {
+  #   :no_cents_if_whole => nil,
+  #   :symbol => nil,
+  #   :sign_before_symbol => nil
+  # }
 end
 ```
 
@@ -400,10 +411,7 @@ end
   only! This rate is added to the attached bank object.
 * ```default_bank```: The default bank object holding exchange rates etc.
   (https://github.com/RubyMoney/money#currency-exchange)
-* ```no_cents_if_whole```: Force `Money#format` method to use its value as the default for ```no_cents_if_whole``` key.
-* ```symbol```: Use its value as the default for ```symbol``` key in
-  `Money#format` method.
-* ```sign_before_symbol```: Force `Money#format` to place the negative sign before the currency symbol.
+* ```default_format```: Force `Money#format` to use these options for formatting.
 * ```amount_column```: Provide values for the amount column (holding the fractional part of a money object).
 * ```currency_column```: Provide default values or even disable (`present: false`) the currency column.
 * ```rounding_mode```: Set Money.rounding_mode to one of the BigDecimal constants

--- a/lib/generators/templates/money.rb
+++ b/lib/generators/templates/money.rb
@@ -58,10 +58,13 @@ MoneyRails.configure do |config|
   #   :decimal_mark        => ","
   # }
 
-  # Set money formatted output globally.
+  # Set default money format globally.
   # Default value is nil meaning "ignore this option".
-  # Options are nil, true, false.
+  # Example:
   #
-  # config.no_cents_if_whole = nil
-  # config.symbol = nil
+  # config.default_format = {
+  #   :no_cents_if_whole => nil,
+  #   :symbol => nil,
+  #   :sign_before_symbol => nil
+  # }
 end

--- a/lib/money-rails/configuration.rb
+++ b/lib/money-rails/configuration.rb
@@ -90,6 +90,9 @@ module MoneyRails
     mattr_accessor :sign_before_symbol
     @@sign_before_symbol = nil
 
+    mattr_accessor :default_format
+    @@default_format = nil
+
     # Configure whether to raise exception when an improper value
     # is going to be converted to a Money object.
     mattr_accessor :raise_error_on_money_parsing

--- a/lib/money-rails/money.rb
+++ b/lib/money-rails/money.rb
@@ -7,7 +7,6 @@ class Money
     rules = normalize_formatting_rules(rules)
 
     # Apply global defaults for money only for non-nil values
-    # TODO: Add here more setting options
     defaults = {
       no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole,
       symbol: MoneyRails::Configuration.symbol,
@@ -15,6 +14,10 @@ class Money
     }.reject { |k,v| v.nil? }
 
     rules.reverse_merge!(defaults)
+
+    unless MoneyRails::Configuration.default_format.nil?
+      rules.reverse_merge!(MoneyRails::Configuration.default_format)
+    end
 
     format_without_settings(rules)
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -72,6 +72,23 @@ describe "configuration" do
       MoneyRails.sign_before_symbol = nil
     end
 
+    it "passes through arbitrary format options" do
+      value = Money.new(-12345600, "EUR")
+      symbol = Money::Currency.find(:eur).symbol
+
+      MoneyRails.default_format = {:symbol_position => :after}
+      value.format.should =~ /#{symbol}\z/
+
+      # Override with "classic" format options for backward compatibility
+      MoneyRails.default_format = {:sign_before_symbol => :false}
+      MoneyRails.sign_before_symbol = true
+      value.format.should =~ /-#{symbol}/
+
+      # Reset global settings
+      MoneyRails.sign_before_symbol = nil
+      MoneyRails.default_format = nil
+    end
+
     it "changes the amount and currency column settings based on the default currency" do
       old_currency = MoneyRails.default_currency
       MoneyRails.default_currency = :inr


### PR DESCRIPTION
Today I was struggling to find a way to pass arbitrary format options through the `humanized_money` helper. All I found in the code was a TODO that more options should be added soon. I think this is not the right way to do it since `money-rails` then must potentially mirror all future format options of the `money` gem.

My PR essentially lets you pass arbitrary format options, not just `:no_cents_if_whole`, `:symbol` and `:sign_before_symbol`. This will account for all options that may exist in the future. For example:

``` ruby
config.default_format = {
  :no_cents_if_whole => true,
  :option_that_nobody_imagined_yet => :of_course
}
```

Cheers
