### PR TITLE
Make it RSpec 3 compatible

### DIFF
--- a/lib/money-rails/test_helpers.rb
+++ b/lib/money-rails/test_helpers.rb
@@ -2,48 +2,64 @@ require 'rspec/expectations'
 
 module MoneyRails
   module TestHelpers
-    extend RSpec::Matchers::DSL
+    def monetize(attribute)
+      MonetizeMatcher.new(attribute)
+    end
 
-    matcher :monetize do |attr|
+    class MonetizeMatcher
+      def initialize(attribute)
+        @attribute = attribute
+      end
 
-      chain(:with_currency) do |currency|
+      def with_currency(currency)
         @currency_iso = currency
+        self
       end
 
-      chain(:as) do |virt_attr|
+      def as(virt_attr)
         @as = virt_attr
+        self
       end
 
-      match do |target|
+      def matches?(actual)
+        @actual = actual
+
         matched = true
-        money_attr = @as.presence || attr.to_s.sub(/_cents$/, "")
-        matched = false if !target.respond_to?(money_attr) ||
-          !target.send(money_attr).instance_of?(Money) ||
+        money_attr = @as.presence || @attribute.to_s.sub(/_cents$/, "")
+        matched = false if !actual.respond_to?(money_attr) ||
+          !actual.send(money_attr).instance_of?(Money) ||
           (@currency_iso &&
-           target.send(money_attr.to_sym).currency.id != @currency_iso)
+           actual.send(money_attr.to_sym).currency.id != @currency_iso)
         matched
       end
 
-      description do
-        description = "monetize #{attr}"
-        description << " as #{@as}" if @as
-        description << " with currency #{@currency_iso}" if @currency_iso
-        description
+      def description
+        desc = "monetize #{@attribute}"
+        desc << " as #{@as}" if @as
+        desc << " with currency #{@currency_iso}" if @currency_iso
+        desc
       end
 
-      failure_message_for_should do |actual|
-        msg = "expected that #{attr} of #{actual} would be monetized"
+      def failure_message # RSpec 3.x
+        msg = "expected that #{@attribute} of #{@actual} would be monetized"
         msg << " as #{@as}" if @as
         msg << " with currency #{@currency_iso}" if @currency_iso
         msg
       end
+      alias_method :failure_message_for_should, :failure_message # RSpec 1.2, 2.x, and minitest-matchers
 
-      failure_message_for_should_not do |actual|
-        msg = "expected that #{attr} of #{actual} would not be monetized"
+      def failure_message_when_negated # RSpec 3.x
+        msg = "expected that #{@attribute} of #{@actual} would not be monetized"
         msg << " as #{@as}" if @as
         msg << " with currency #{@currency_iso}" if @currency_iso
         msg
       end
+      alias_method :failure_message_for_should_not, :failure_message_when_negated # RSpec 1.2, 2.x, and minitest-matchers
+      alias_method :negative_failure_message,       :failure_message_when_negated # RSpec 1.1
     end
   end
+end
+
+RSpec.configure do |config|
+  config.include MoneyRails::TestHelpers
 end


### PR DESCRIPTION
RSpec changes its matcher DSL in RSpec 3.0.0, which deprecated the `Matcher#failure_message_for_should` and `Matcher#failure_message_for_should_not`. 
Quoted from http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3

> ### Changes to the matcher protocol
> 
> As mentioned above, in RSpec 3, we no longer consider should to be the main syntax of rspec-expectations. We’ve updated the matcher protocol to reflect this:
> `failure_message_for_should` is now `failure_message`.
> `failure_message_for_should_not` is now `failure_message_when_negated`.
> `match_for_should` (an alias of match in the custom matcher DSL) has been removed with no replacement. (Just use match).
> `match_for_should_not` in the custom matcher DSL is now `match_when_negated`.

This PR change the original block defined custom matcher to a matcher class, which allow us to also alias method to compatible with older versions of RSpec.

Please check if this is applicable, thanks :-)
