### PR TITLE
Show actual value in validation message for easier debugging

### DIFF
--- a/config/locales/money.en.yml
+++ b/config/locales/money.en.yml
@@ -1,5 +1,5 @@
 en:
   errors:
     messages:
-      invalid_currency: Must be a valid currency (eg. '100', '5%{decimal}24', or '123%{thousands}456%{decimal}78')
+      invalid_currency: Must be a valid currency (eg. '100', '5%{decimal}24', or '123%{thousands}456%{decimal}78'). Got %{currency}
 

--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -47,7 +47,8 @@ module MoneyRails
           unless [1, 2].include? decimal_pieces.length
             record.errors.add(attr, I18n.t('errors.messages.invalid_currency',
                                            { :thousands => thousands_separator,
-                                             :decimal => decimal_mark }))
+                                             :decimal => decimal_mark,
+                                             :currency => abs_raw_value }))
             return
           end
 
@@ -57,11 +58,13 @@ module MoneyRails
           if pieces.length > 1
             record.errors.add(attr, I18n.t('errors.messages.invalid_currency',
                                            { :thousands => thousands_separator,
-                                             :decimal => decimal_mark })) if pieces[0].length > 3
+                                             :decimal => decimal_mark,
+                                             :currency => abs_raw_value })) if pieces[0].length > 3
             (1..pieces.length-1).each do |index|
               record.errors.add(attr, I18n.t('errors.messages.invalid_currency',
                                              { :thousands => thousands_separator,
-                                               :decimal => decimal_mark })) if pieces[index].length != 3
+                                               :decimal => decimal_mark,
+                                               :currency => abs_raw_value })) if pieces[index].length != 3
             end
           end
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -107,18 +107,21 @@ if defined? ActiveRecord
         product.price = "12.23.24"
         product.save.should eq(false)
         product.errors[:price].first.should match(/Must be a valid/)
+        product.errors[:price].first.should match(/Got 12.23.24/)
       end
 
       it "fails validation with the proper error message if money value is nothing but periods" do
         product.price = "..."
         product.save.should eq(false)
         product.errors[:price].first.should match(/Must be a valid/)
+        product.errors[:price].first.should match(/Got .../)
       end
 
       it "fails validation with the proper error message if money value has invalid thousands part" do
         product.price = "12,23.24"
         product.save.should eq(false)
         product.errors[:price].first.should match(/Must be a valid/)
+        product.errors[:price].first.should match(/Got 12,23.24/)
       end
 
       it "passes validation if money value is a Float and the currency decimal mark is not period" do


### PR DESCRIPTION
So validation message looks like this: "Must be a valid currency (eg. '100', '5.24', or '123,456.78'). Got 12,23.24"
