### PR TITLE
Allow empty string be a thousands separator

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -52,7 +52,7 @@ module MoneyRails
             return
           end
 
-          pieces = decimal_pieces[0].split(thousands_separator)
+          pieces = decimal_pieces[0].split(thousands_separator.presence)
 
           # check for valid thousands separation
           if pieces.length > 1

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -124,6 +124,16 @@ if defined? ActiveRecord
         product.errors[:price].first.should match(/Got 12,23.24/)
       end
 
+      it "allow to have empty string as thousands separator" do
+        begin
+          I18n.locale = 'en-US'
+          product.price = '10.00'
+          product.should be_valid
+        ensure
+          I18n.locale = I18n.default_locale
+        end
+      end
+
       it "passes validation if money value is a Float and the currency decimal mark is not period" do
         # The corresponding String would be "12,34" euros
         service.discount = 12.34

--- a/spec/dummy/app/models/dummy_product.rb
+++ b/spec/dummy/app/models/dummy_product.rb
@@ -5,3 +5,4 @@ class DummyProduct < ActiveRecord::Base
   # Use money-rails macros
   monetize :price_cents, :with_model_currency => :currency
 end
+

--- a/spec/dummy/config/locales/en-US.yml
+++ b/spec/dummy/config/locales/en-US.yml
@@ -1,0 +1,5 @@
+en-US:
+  number:
+    currency:
+      format:
+        delimiter: ''


### PR DESCRIPTION
If you pass empty string as thousands separator every price greater than two symbols would be invalid. For example:

``` yml
# config/locales/en.yml
en:
  number:
    currency:
      format:
        delimiter: ''
```

``` ruby
product.price = '10.00'
product.valid? #=> false
```

This may be fixed be replacing delimiter by `nil` but I think that in sake of convenience it's better to check that case on the `money-rails` side.
