### PR TITLE
Allowing aliased attributes to be monetized

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -156,7 +156,12 @@ module MoneyRails
             end
 
             # Update cents
-            write_attribute(subunit_name, money.try(:cents))
+            if self.class.attribute_alias?(subunit_name)
+              original_name = self.class.attribute_aliases[subunit_name.to_s]
+              write_attribute(original_name, money.try(:cents))
+            else
+              write_attribute(subunit_name, money.try(:cents))
+            end
 
             money_currency = money.try(:currency)
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -449,6 +449,14 @@ if defined? ActiveRecord
         product.optional_price.should be_nil
       end
 
+
+      context "when the monetized field is an aliased attribute" do
+        it "writes the subunits to the original (unaliased) column" do
+          product.renamed = "$10.00"
+          expect(product.aliased_cents).to eq 10_00
+        end
+      end
+
       context "for column with model currency:" do
         it "has default currency if not specified" do
           product = Product.create(:sale_price_amount => 1234)

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -39,4 +39,8 @@ class Product < ActiveRecord::Base
     :less_than_or_equal_to => 100,
     :message => 'Must be greater than zero and less than $100',
   }
+
+  alias_attribute :renamed_cents, :aliased_cents
+
+  monetize :renamed_cents, allow_nil: true
 end

--- a/spec/dummy/db/migrate/20141005075025_add_aliased_attr_to_products.rb
+++ b/spec/dummy/db/migrate/20141005075025_add_aliased_attr_to_products.rb
@@ -1,0 +1,5 @@
+class AddAliasedAttrToProducts < ActiveRecord::Migration
+  def change
+    add_column :products, :aliased_cents, :integer
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140110194016) do
+ActiveRecord::Schema.define(version: 20141005075025) do
 
   create_table "dummy_products", force: true do |t|
     t.string   "currency"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20140110194016) do
     t.string   "sale_price_currency_code"
     t.integer  "price_in_a_range_cents"
     t.integer  "validates_method_amount_cents"
+    t.integer  "aliased_cents"
   end
 
   create_table "services", force: true do |t|


### PR DESCRIPTION
Turns out that my last pull request introduced a bug: trying to write to a monetized aliased attribute would raise an error. This commit fixes that.
