### PR TITLE
Monetizable assignment

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -151,6 +151,9 @@ module MoneyRails
                 rescue ArgumentError
                   raise if MoneyRails.raise_error_on_money_parsing
                   return nil
+                rescue Money::Currency::UnknownCurrency
+                  raise if MoneyRails.raise_error_on_money_parsing
+                  return nil
                 end
               end
             end

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -85,11 +85,19 @@ if defined? ActiveRecord
         it "raises exception when a String value with hyphen is assigned" do
           expect { product.invalid_price = "10-235" }.to raise_error
         end
+
+        it "raises exception when an alpha String is assigned" do
+          expect { product.invalid_price = "NA" }.to raise_error
+        end
       end
 
       context "when MoneyRails.raise_error_on_money_parsing is false (default)" do
         it "does not raise exception when a String value with hyphen is assigned" do
           expect { product.invalid_price = "10-235" }.not_to raise_error
+        end
+
+        it "does not raise an exception when an alpha String is assigned" do
+          expect { product.invalid_price = "NA" }.not_to raise_error
         end
       end
 


### PR DESCRIPTION
We where having an issue where users were setting currency inputs to "na" and money-rails was throwing an exception before validations had a chance to inform the user of their error (even with `[MoneyRails.raise_error_on_money_parsing]` set to `false`).

The simplest solution seems to be to capture `[Money::Currency::UnknownCurrency]` errors and only bubble them up if `[MoneyRails.raise_error_on_money_parsing]` is set to true.
