### PR TITLE
Removed additional underscore in postfix comment.

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -38,7 +38,7 @@ module MoneyRails
 
           # Form target name for the money backed ActiveModel field:
           # if a target name is provided then use it
-          # if there is a "_{column.postfix}" suffix then just remove it to create the target name
+          # if there is a "{column.postfix}" suffix then just remove it to create the target name
           # if none of the previous is the case then use a default suffix
           if name
             name = name.to_s


### PR DESCRIPTION
The suffix includes the initial underscore, if it's present.

i.e. you set the postfix to be something like: `postfix: '_in_cents'`, not `postfix: 'in_cents'`
