### PR TITLE
Improvements to `monetize` test matcher.

### DIFF
--- a/spec/test_helpers_spec.rb
+++ b/spec/test_helpers_spec.rb
@@ -14,38 +14,50 @@ if defined? ActiveRecord
     end
 
     describe "monetize matcher" do
-      it "matches model attribute without a '_cents' suffix by default" do
-        expect(product).to monetize(:price_cents)
+
+      shared_context "monetize matcher" do
+
+        it "matches model attribute without a '_cents' suffix by default" do
+          is_expected.to monetize(:price_cents)
+        end
+
+        it "matches model attribute specified by :as chain" do
+          is_expected.to monetize(:discount).as(:discount_value)
+        end
+
+        it "matches model attribute with nil value specified by :allow_nil chain" do
+          is_expected.to monetize(:optional_price).allow_nil
+        end
+
+        it "matches nullable model attribute when tested instance has a non-nil value" do
+          is_expected.to monetize(:optional_price).allow_nil
+        end
+
+        it "matches model attribute with currency specified by :with_currency chain" do
+          is_expected.to monetize(:bonus_cents).with_currency(:gbp)
+        end
+
+        it "does not match non existed attribute" do
+          is_expected.not_to monetize(:price_fake)
+        end
+
+        it "does not match wrong currency iso" do
+          is_expected.not_to monetize(:bonus_cents).with_currency(:usd)
+        end
+
+        it "does not match wrong money attribute name" do
+          is_expected.not_to monetize(:bonus_cents).as(:bonussss)
+        end
       end
 
-      it "matches model attribute specified by :as chain" do
-        expect(product).to monetize(:discount).as(:discount_value)
-      end
-
-      it "matches model attribute with nil value specified by :allow_nil chain" do
-        expect(product).to monetize(:optional_price).allow_nil
-      end
-
-      it "matches model attribute with currency specified by :with_currency chain" do
-        expect(product).to monetize(:bonus_cents).with_currency(:gbp)
-      end
-
-      it "does not match non existed attribute" do
-        expect(product).not_to monetize(:price_fake)
-      end
-
-      it "does not match wrong currency iso" do
-        expect(product).not_to monetize(:bonus_cents).with_currency(:usd)
-      end
-
-      it "does not match wrong money attribute name" do
-        expect(product).not_to monetize(:bonus_cents).as(:bonussss)
-      end
-
-      context "using subject" do
+      describe "testing against an instance of the model class" do
         subject { product }
+        include_context "monetize matcher"
+      end
 
-        it { is_expected.to monetize(:price_cents) }
+      describe "testing against the model class itself" do
+        subject { Product }
+        include_context "monetize matcher"
       end
     end
   end


### PR DESCRIPTION
Improvement over my other PR #255  - see the description there.

Basically, this allows the `monetize` matcher to be used with the ActiveRecord class itself as the subject, as well as an instance of that class.

E.g., assuming the AR class is called `Project` and has a monetized attribute called `price_cents`:

```
describe Product do
  let(:product) { Product.new(price_cents: whatever) }

  # This is the old way of doing it.
  it { expect(product).to monetize(:price_cents) }

  # "Product" as implicit subject. This previously didn't work; the PR makes it work.
  it { is_expected.to monetize(:price_cents) }
end
```

This feels more intuitive to me, and it's how shoulda-matchers does it.

On top of that, these changes mean that, even if you _do_ test against an instance of Product, it doesn't matter 
what the value of the attribute is at runtime. Previously, the first example above might not pass depending on the specific value of `whatever`... which doesn't make sense because the attribute _is_ monetized ("monetize :price_cents" is called within the class definition) so the spec should pass regardless of the specifics of any particular instance.
