### PR TITLE
Add Rails 4.2 spec and update money dependency to 6.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ gemfile:
   - gemfiles/rails3.gemfile
   - gemfiles/rails4.gemfile
   - gemfiles/rails41.gemfile
+  - gemfiles/rails42.gemfile
 matrix:
   exclude:
     - rvm: 1.9.2

--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,9 @@ namespace :spec do
   desc "Run Tests against mongoid (version 2)"
   task(:mongoid2) { run_with_gemfile 'gemfiles/mongoid2.gemfile' }
 
+  desc "Run Tests against rails 4.2"
+  task(:rails42) { run_with_gemfile 'gemfiles/rails42.gemfile' }
+
   desc "Run Tests against rails 4.1"
   task(:rails41) { run_with_gemfile 'gemfiles/rails41.gemfile' }
 
@@ -59,8 +62,8 @@ namespace :spec do
   desc "Run Tests against mongoid 2 & 3 & 4"
   task :mongoid => [:mongoid2, :mongoid3, :mongoid4]
 
-  desc "Run Tests against rails 3 & 4 & 4.1"
-  task :rails => [:rails3, :rails4, :rails41]
+  desc "Run Tests against rails 3 & 4 & 4.1 & 4.2"
+  task :rails => [:rails3, :rails4, :rails41, :rails42]
 
   desc "Run Tests against all ORMs"
   task :all => [:rails, :mongoid]

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 4.2.0'
+
+platforms :jruby do
+  gem "activerecord-jdbc-adapter"
+  gem "activerecord-jdbcsqlite3-adapter"
+  gem "jruby-openssl"
+end
+
+platforms :ruby do
+  gem "sqlite3"
+end
+
+gemspec :path => '../'

--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_dependency "money",         "~> 6.4.0"
-  s.add_dependency "monetize",      "~> 1.0.0"
+  s.add_dependency "money",         "~> 6.5.0"
+  s.add_dependency "monetize",      "~> 1.1.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"
 


### PR DESCRIPTION
I don't believe specs will work until a new version of `monetize` is cut with the money "~> 6.5.0" dependency.
