### PR TITLE
Support multiple attributes w/ one call for AR

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -8,227 +8,229 @@ module MoneyRails
       extend ActiveSupport::Concern
 
       module ClassMethods
-        def monetize(field, *args)
-          options = args.extract_options!
+        def monetize(*fields)
+          options = fields.extract_options!
 
-          # Stringify model field name
-          subunit_name = field.to_s
+          fields.each do |field|
+            # Stringify model field name
+            subunit_name = field.to_s
 
-          if options[:field_currency] || options[:target_name] ||
-            options[:model_currency]
-            ActiveSupport::Deprecation.warn("You are using the old " \
-              "argument keys of the monetize command! Instead use :as, " \
-              ":with_currency or :with_model_currency")
-          end
-
-          # Optional accessor to be run on an instance to detect currency
-          instance_currency_name = options[:with_model_currency] ||
-            options[:model_currency] ||
-            MoneyRails::Configuration.currency_column[:column_name]
-
-          instance_currency_name = instance_currency_name &&
-            instance_currency_name.to_s
-
-          # This attribute allows per column currency values
-          # Overrides row and default currency
-          field_currency_name = options[:with_currency] ||
-            options[:field_currency] || nil
-
-          name = options[:as] || options[:target_name] || nil
-
-          # Form target name for the money backed ActiveModel field:
-          # if a target name is provided then use it
-          # if there is a "{column.postfix}" suffix then just remove it to create the target name
-          # if none of the previous is the case then use a default suffix
-          if name
-            name = name.to_s
-          elsif subunit_name =~ /#{MoneyRails::Configuration.amount_column[:postfix]}$/
-            name = subunit_name.sub(/#{MoneyRails::Configuration.amount_column[:postfix]}$/, "")
-          else
-            # FIXME: provide a better default
-            name = [subunit_name, "money"].join("_")
-          end
-
-          # Create a reverse mapping of the monetized attributes
-          @monetized_attributes ||= {}.with_indifferent_access
-          if @monetized_attributes[name].present?
-            raise ArgumentError, "#{self} already has a monetized attribute called '#{name}'"
-          end
-          @monetized_attributes[name] = subunit_name
-          class << self
-            def monetized_attributes
-              @monetized_attributes || superclass.monetized_attributes
+            if options[:field_currency] || options[:target_name] ||
+              options[:model_currency]
+              ActiveSupport::Deprecation.warn("You are using the old " \
+                "argument keys of the monetize command! Instead use :as, " \
+                ":with_currency or :with_model_currency")
             end
-          end unless respond_to? :monetized_attributes
 
-          # Include numericality validations if needed.
-          # There are two validation options:
-          #
-          # 1. Subunit field validation (e.g. cents should be > 100)
-          # 2. Money field validation (e.g. euros should be > 10)
-          #
-          # All the options which are available for Rails numericality
-          # validation, are also available for both types.
-          # E.g.
-          #   monetize :price_in_a_range_cents, :allow_nil => true,
-          #     :subunit_numericality => {
-          #       :greater_than_or_equal_to => 0,
-          #       :less_than_or_equal_to => 10000,
-          #     },
-          #     :numericality => {
-          #       :greater_than_or_equal_to => 0,
-          #       :less_than_or_equal_to => 100,
-          #       :message => "Must be greater than zero and less than $100"
-          #     }
-          #
-          # To disable validation entirely, use :disable_validation, E.g:
-          #   monetize :price_in_a_range_cents, :disable_validation => true
-          if validation_enabled = MoneyRails.include_validations && !options[:disable_validation]
+            # Optional accessor to be run on an instance to detect currency
+            instance_currency_name = options[:with_model_currency] ||
+              options[:model_currency] ||
+              MoneyRails::Configuration.currency_column[:column_name]
 
-            subunit_validation_options =
-              unless options.has_key? :subunit_numericality
-                true
-              else
-                options[:subunit_numericality]
-              end
+            instance_currency_name = instance_currency_name &&
+              instance_currency_name.to_s
 
-            money_validation_options =
-              unless options.has_key? :numericality
-                true
-              else
-                options[:numericality]
-              end
+            # This attribute allows per column currency values
+            # Overrides row and default currency
+            field_currency_name = options[:with_currency] ||
+              options[:field_currency] || nil
 
-            # This is a validation for the subunit
-            validates subunit_name, {
-              :allow_nil => options[:allow_nil],
-              :numericality => subunit_validation_options
-            }
+            name = options[:as] || options[:target_name] || nil
 
-            # Allow only Money objects or Numeric values!
-            validates name.to_sym, {
-              :allow_nil => options[:allow_nil],
-              'money_rails/active_model/money' => money_validation_options
-            }
-          end
-
-
-          define_method name do |*args|
-
-            # Get the cents
-            amount = public_send(subunit_name, *args)
-
-            # Get the currency object
-            attr_currency = public_send("currency_for_#{name}")
-
-            # Get the cached value
-            memoized = instance_variable_get("@#{name}")
-
-            # Dont create a new Money instance if the values haven't been changed.
-            return memoized if memoized && memoized.cents == amount &&
-              memoized.currency == attr_currency
-
-            # If amount is NOT nil (or empty string) load the amount in a Money
-            amount = Money.new(amount, attr_currency) unless amount.blank?
-
-            # Cache and return the value (it may be nil)
-            instance_variable_set "@#{name}", amount
-          end
-
-          define_method "#{name}=" do |value|
-
-            # Lets keep the before_type_cast value
-            instance_variable_set "@#{name}_money_before_type_cast", value
-
-            # Use nil or get a Money object
-            if options[:allow_nil] && value.blank?
-              money = nil
+            # Form target name for the money backed ActiveModel field:
+            # if a target name is provided then use it
+            # if there is a "{column.postfix}" suffix then just remove it to create the target name
+            # if none of the previous is the case then use a default suffix
+            if name
+              name = name.to_s
+            elsif subunit_name =~ /#{MoneyRails::Configuration.amount_column[:postfix]}$/
+              name = subunit_name.sub(/#{MoneyRails::Configuration.amount_column[:postfix]}$/, "")
             else
-              if value.is_a?(Money)
-                money = value
+              # FIXME: provide a better default
+              name = [subunit_name, "money"].join("_")
+            end
+
+            # Create a reverse mapping of the monetized attributes
+            @monetized_attributes ||= {}.with_indifferent_access
+            if @monetized_attributes[name].present?
+              raise ArgumentError, "#{self} already has a monetized attribute called '#{name}'"
+            end
+            @monetized_attributes[name] = subunit_name
+            class << self
+              def monetized_attributes
+                @monetized_attributes || superclass.monetized_attributes
+              end
+            end unless respond_to? :monetized_attributes
+
+            # Include numericality validations if needed.
+            # There are two validation options:
+            #
+            # 1. Subunit field validation (e.g. cents should be > 100)
+            # 2. Money field validation (e.g. euros should be > 10)
+            #
+            # All the options which are available for Rails numericality
+            # validation, are also available for both types.
+            # E.g.
+            #   monetize :price_in_a_range_cents, :allow_nil => true,
+            #     :subunit_numericality => {
+            #       :greater_than_or_equal_to => 0,
+            #       :less_than_or_equal_to => 10000,
+            #     },
+            #     :numericality => {
+            #       :greater_than_or_equal_to => 0,
+            #       :less_than_or_equal_to => 100,
+            #       :message => "Must be greater than zero and less than $100"
+            #     }
+            #
+            # To disable validation entirely, use :disable_validation, E.g:
+            #   monetize :price_in_a_range_cents, :disable_validation => true
+            if validation_enabled = MoneyRails.include_validations && !options[:disable_validation]
+
+              subunit_validation_options =
+                unless options.has_key? :subunit_numericality
+                  true
+                else
+                  options[:subunit_numericality]
+                end
+
+              money_validation_options =
+                unless options.has_key? :numericality
+                  true
+                else
+                  options[:numericality]
+                end
+
+              # This is a validation for the subunit
+              validates subunit_name, {
+                :allow_nil => options[:allow_nil],
+                :numericality => subunit_validation_options
+              }
+
+              # Allow only Money objects or Numeric values!
+              validates name.to_sym, {
+                :allow_nil => options[:allow_nil],
+                'money_rails/active_model/money' => money_validation_options
+              }
+            end
+
+
+            define_method name do |*args|
+
+              # Get the cents
+              amount = public_send(subunit_name, *args)
+
+              # Get the currency object
+              attr_currency = public_send("currency_for_#{name}")
+
+              # Get the cached value
+              memoized = instance_variable_get("@#{name}")
+
+              # Dont create a new Money instance if the values haven't been changed.
+              return memoized if memoized && memoized.cents == amount &&
+                memoized.currency == attr_currency
+
+              # If amount is NOT nil (or empty string) load the amount in a Money
+              amount = Money.new(amount, attr_currency) unless amount.blank?
+
+              # Cache and return the value (it may be nil)
+              instance_variable_set "@#{name}", amount
+            end
+
+            define_method "#{name}=" do |value|
+
+              # Lets keep the before_type_cast value
+              instance_variable_set "@#{name}_money_before_type_cast", value
+
+              # Use nil or get a Money object
+              if options[:allow_nil] && value.blank?
+                money = nil
               else
-                begin
-                  money = value.to_money(public_send("currency_for_#{name}"))
-                rescue NoMethodError
-                  return nil
-                rescue ArgumentError
-                  raise if MoneyRails.raise_error_on_money_parsing
-                  return nil
-                rescue Money::Currency::UnknownCurrency
-                  raise if MoneyRails.raise_error_on_money_parsing
-                  return nil
+                if value.is_a?(Money)
+                  money = value
+                else
+                  begin
+                    money = value.to_money(public_send("currency_for_#{name}"))
+                  rescue NoMethodError
+                    return nil
+                  rescue ArgumentError
+                    raise if MoneyRails.raise_error_on_money_parsing
+                    return nil
+                  rescue Money::Currency::UnknownCurrency
+                    raise if MoneyRails.raise_error_on_money_parsing
+                    return nil
+                  end
                 end
               end
+
+              # Update cents
+              if !validation_enabled
+                # We haven't defined our own subunit writer, so we can invoke
+                # the regular writer, which works with store_accessors
+                public_send("#{subunit_name}=", money.try(:cents))
+              elsif self.class.respond_to?(:attribute_aliases) &&
+                    self.class.attribute_aliases.key?(subunit_name)
+                # If the attribute is aliased, make sure we write to the original
+                # attribute name or an error will be raised.
+                # (Note: 'attribute_aliases' doesn't exist in Rails 3.x, so we
+                # can't tell if the attribute was aliased.)
+                original_name = self.class.attribute_aliases[subunit_name.to_s]
+                write_attribute(original_name, money.try(:cents))
+              else
+                write_attribute(subunit_name, money.try(:cents))
+              end
+
+              money_currency = money.try(:currency)
+
+              # Update currency iso value if there is an instance currency attribute
+              if instance_currency_name.present? &&
+                respond_to?("#{instance_currency_name}=")
+
+                public_send("#{instance_currency_name}=", money_currency.try(:iso_code))
+              else
+                current_currency = public_send("currency_for_#{name}")
+                if money_currency && current_currency != money_currency.id
+                  raise "Can't change readonly currency '#{current_currency}' to '#{money_currency}' for field '#{name}'"
+                end
+              end
+
+              # Save and return the new Money object
+              instance_variable_set "@#{name}", money
             end
 
-            # Update cents
-            if !validation_enabled
-              # We haven't defined our own subunit writer, so we can invoke
-              # the regular writer, which works with store_accessors
-              public_send("#{subunit_name}=", money.try(:cents))
-            elsif self.class.respond_to?(:attribute_aliases) &&
-                  self.class.attribute_aliases.key?(subunit_name)
-              # If the attribute is aliased, make sure we write to the original
-              # attribute name or an error will be raised.
-              # (Note: 'attribute_aliases' doesn't exist in Rails 3.x, so we
-              # can't tell if the attribute was aliased.)
-              original_name = self.class.attribute_aliases[subunit_name.to_s]
-              write_attribute(original_name, money.try(:cents))
-            else
-              write_attribute(subunit_name, money.try(:cents))
-            end
-
-            money_currency = money.try(:currency)
-
-            # Update currency iso value if there is an instance currency attribute
-            if instance_currency_name.present? &&
-              respond_to?("#{instance_currency_name}=")
-
-              public_send("#{instance_currency_name}=", money_currency.try(:iso_code))
-            else
-              current_currency = public_send("currency_for_#{name}")
-              if money_currency && current_currency != money_currency.id
-                raise "Can't change readonly currency '#{current_currency}' to '#{money_currency}' for field '#{name}'"
+            if validation_enabled
+              # Ensure that the before_type_cast value is cleared when setting
+              # the subunit value directly
+              define_method "#{subunit_name}=" do |value|
+                instance_variable_set "@#{name}_money_before_type_cast", nil
+                write_attribute(subunit_name, value)
               end
             end
 
-            # Save and return the new Money object
-            instance_variable_set "@#{name}", money
-          end
+            define_method "currency_for_#{name}" do
+              if instance_currency_name.present? &&
+                respond_to?(instance_currency_name) &&
+                public_send(instance_currency_name).present? &&
+                Money::Currency.find(public_send(instance_currency_name))
 
-          if validation_enabled
-            # Ensure that the before_type_cast value is cleared when setting
-            # the subunit value directly
-            define_method "#{subunit_name}=" do |value|
+                Money::Currency.find(public_send(instance_currency_name))
+              elsif field_currency_name
+                Money::Currency.find(field_currency_name)
+              elsif self.class.respond_to?(:currency)
+                self.class.currency
+              else
+                Money.default_currency
+              end
+            end
+
+            define_method "#{name}_money_before_type_cast" do
+              instance_variable_get "@#{name}_money_before_type_cast"
+            end
+
+            # Hook to ensure the reset of before_type_cast attr
+            # TODO: think of a better way to avoid this
+            after_save do
               instance_variable_set "@#{name}_money_before_type_cast", nil
-              write_attribute(subunit_name, value)
             end
-          end
-
-          define_method "currency_for_#{name}" do
-            if instance_currency_name.present? &&
-              respond_to?(instance_currency_name) &&
-              public_send(instance_currency_name).present? &&
-              Money::Currency.find(public_send(instance_currency_name))
-
-              Money::Currency.find(public_send(instance_currency_name))
-            elsif field_currency_name
-              Money::Currency.find(field_currency_name)
-            elsif self.class.respond_to?(:currency)
-              self.class.currency
-            else
-              Money.default_currency
-            end
-          end
-
-          define_method "#{name}_money_before_type_cast" do
-            instance_variable_get "@#{name}_money_before_type_cast"
-          end
-
-          # Hook to ensure the reset of before_type_cast attr
-          # TODO: think of a better way to avoid this
-          after_save do
-            instance_variable_set "@#{name}_money_before_type_cast", nil
           end
         end
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -8,7 +8,8 @@ if defined? ActiveRecord
       let(:product) do
         Product.create(:price_cents => 3000, :discount => 150,
                        :bonus_cents => 200, :optional_price => 100,
-                       :sale_price_amount => 1200)
+                       :sale_price_amount => 1200, :delivery_fee_cents => 100,
+                       :restock_fee_cents => 2000)
       end
 
       let(:service) do
@@ -23,6 +24,11 @@ if defined? ActiveRecord
         expect(product.price).to be_an_instance_of(Money)
         expect(product.discount_value).to be_an_instance_of(Money)
         expect(product.bonus).to be_an_instance_of(Money)
+      end
+
+      it "attaches Money objects to multiple model fields" do
+        expect(product.delivery_fee).to be_an_instance_of(Money)
+        expect(product.restock_fee).to be_an_instance_of(Money)
       end
 
       it "returns the expected money amount as a Money object" do

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -5,6 +5,9 @@ class Product < ActiveRecord::Base
   # Use money-rails macros
   monetize :price_cents
 
+  # Use money-rails macro with multiple fields
+  monetize :delivery_fee_cents, :restock_fee_cents, :allow_nil => true
+
   # Use a custom name for the Money attribute
   monetize :discount, :as => "discount_value"
 

--- a/spec/dummy/db/migrate/20150107061030_add_delivery_fee_cents_and_restock_fee_cents_to_product.rb
+++ b/spec/dummy/db/migrate/20150107061030_add_delivery_fee_cents_and_restock_fee_cents_to_product.rb
@@ -1,0 +1,6 @@
+class AddDeliveryFeeCentsAndRestockFeeCentsToProduct < ActiveRecord::Migration
+  def change
+    add_column :products, :delivery_fee_cents, :integer
+    add_column :products, :restock_fee_cents, :integer
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141005075025) do
+ActiveRecord::Schema.define(version: 20150107061030) do
 
   create_table "dummy_products", force: true do |t|
     t.string   "currency"
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 20141005075025) do
     t.integer  "price_in_a_range_cents"
     t.integer  "validates_method_amount_cents"
     t.integer  "aliased_cents"
+    t.integer  "delivery_fee_cents"
+    t.integer  "restock_fee_cents"
   end
 
   create_table "services", force: true do |t|


### PR DESCRIPTION
Adjust usage of `extract_options!` to accept multiple attributes and provide a more Rails-y behavior (similar to `validates`, `delegate`, etc.)

Besides the argument changes, it's just the original code in a loop.

Ex:

```ruby
class Product
  monetize :field_one, :field_two, :field_three, :option => 'value'
end
```

This will raise an error if multiple attributes are used with the `:as` option. That's intentional since it's an attempt to name multiple attributes with the same name. Other options should be ok.