### PR TITLE
Using currency_column[:postfix] to automatically determine currency column

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -207,14 +207,19 @@ module MoneyRails
             end
 
             define_method "currency_for_#{name}" do
+              instance_currency_name_with_postfix = "#{name}#{MoneyRails::Configuration.currency_column[:postfix]}"
+
               if instance_currency_name.present? &&
                 respond_to?(instance_currency_name) &&
-                public_send(instance_currency_name).present? &&
                 Money::Currency.find(public_send(instance_currency_name))
 
                 Money::Currency.find(public_send(instance_currency_name))
               elsif field_currency_name
                 Money::Currency.find(field_currency_name)
+              elsif respond_to?(instance_currency_name_with_postfix) &&
+                Money::Currency.find(public_send(instance_currency_name_with_postfix))
+
+                Money::Currency.find(public_send(instance_currency_name_with_postfix))
               elsif self.class.respond_to?(:currency)
                 self.class.currency
               else

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -9,7 +9,8 @@ if defined? ActiveRecord
         Product.create(:price_cents => 3000, :discount => 150,
                        :bonus_cents => 200, :optional_price => 100,
                        :sale_price_amount => 1200, :delivery_fee_cents => 100,
-                       :restock_fee_cents => 2000)
+                       :restock_fee_cents => 2000,
+                       :reduced_price_cents => 1500, :reduced_price_currency => :lvl)
       end
 
       let(:service) do
@@ -354,6 +355,10 @@ if defined? ActiveRecord
       it "overrides default currency with the value of :with_currency argument" do
         expect(service.charge.currency).to eq(Money::Currency.find(:usd))
         expect(product.bonus.currency).to eq(Money::Currency.find(:gbp))
+      end
+
+      it "uses currency postfix to determine attribute that stores currency" do
+        expect(product.reduced_price.currency).to eq(Money::Currency.find(:lvl))
       end
 
       it "correctly assigns Money objects to the attribute" do

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -46,4 +46,7 @@ class Product < ActiveRecord::Base
   alias_attribute :renamed_cents, :aliased_cents
 
   monetize :renamed_cents, allow_nil: true
+
+  # Using postfix to determine currency column (reduced_price_currency)
+  monetize :reduced_price_cents, :allow_nil => true
 end

--- a/spec/dummy/db/migrate/20150126231442_add_reduced_price_to_products.rb
+++ b/spec/dummy/db/migrate/20150126231442_add_reduced_price_to_products.rb
@@ -1,0 +1,6 @@
+class AddReducedPriceToProducts < ActiveRecord::Migration
+  def change
+    add_column :products, :reduced_price_cents, :integer
+    add_column :products, :reduced_price_currency, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150107061030) do
+ActiveRecord::Schema.define(version: 20150126231442) do
 
   create_table "dummy_products", force: true do |t|
     t.string   "currency"
@@ -34,6 +34,8 @@ ActiveRecord::Schema.define(version: 20150107061030) do
     t.integer  "aliased_cents"
     t.integer  "delivery_fee_cents"
     t.integer  "restock_fee_cents"
+    t.integer  "reduced_price_cents"
+    t.string   "reduced_price_currency"
   end
 
   create_table "services", force: true do |t|


### PR DESCRIPTION
Obviously the `:postfix` option for `currency_column` was not used at all, so I decided to implement it.

Basically it will try to find an attribute based on `name` and `currency_column[:postfix]` and if there is one — use it to get currency value.

I also removed `public_send(instance_currency_name).present?` because it is redundant and  `Money::Currency.find` can handle empty strings and `nil`s itself, returning `nil` in those cases.