### PR TITLE
Remove guard from validation

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -6,11 +6,7 @@ module MoneyRails
         @record = record
         @attr = attr
 
-        # If subunit is not set then no need to validate as it is an
-        # indicator that no assignment has been done onto the virtual
-        # money field.
         subunit_attr = @record.class.monetized_attributes[@attr.to_sym]
-        return unless @record.changed_attributes.keys.include? subunit_attr
 
         # WARNING: Currently this is only defined in ActiveRecord extension!
         before_type_cast = :"#{@attr}_money_before_type_cast"

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -200,6 +200,15 @@ if defined? ActiveRecord
         expect(product.errors[:price_in_a_range].first).to match(/Must be greater than zero and less than \$100/)
       end
 
+      it "fails validation if linked attribute changed" do
+        product = Product.create(:price => Money.new(3210, "USD"), :discount => 150,
+                                 :validates_method_amount => 100,
+                                 :bonus_cents => 200, :optional_price => 100)
+        expect(product.valid?).to be_truthy
+        product.optional_price = 50
+        expect(product.valid?).to be_falsey
+      end
+
       it "fails validation with the proper error message using validates :money" do
         product.validates_method_amount = "-12"
         expect(product.valid?).to be_falsey

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -39,9 +39,9 @@ class Product < ActiveRecord::Base
 
   validates :validates_method_amount, :money => {
     :greater_than => 0,
-    :less_than_or_equal_to => 100,
+    :less_than_or_equal_to => ->(product) { product.optional_price.to_f },
     :message => 'Must be greater than zero and less than $100',
-  }
+  }, allow_nil: true
 
   alias_attribute :renamed_cents, :aliased_cents
 


### PR DESCRIPTION
We can't use this guard, cause sometimes validation depends on another field instead of constant value, and if we change linked field validation will be skipped.