### PR TITLE
Fix .monetized_attributes class method

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -58,7 +58,11 @@ module MoneyRails
             @monetized_attributes[name] = subunit_name
             class << self
               def monetized_attributes
-                @monetized_attributes || superclass.monetized_attributes
+                if @monetized_attributes && superclass.respond_to?(:monetized_attributes)
+                    @monetized_attributes.merge(superclass.monetized_attributes)
+                else
+                  @monetized_attributes || superclass.monetized_attributes
+                end
               end
             end unless respond_to? :monetized_attributes
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 class Sub < Product; end
 
+class SubProduct < Product
+  monetize :special_price_cents
+end
+
 if defined? ActiveRecord
   describe MoneyRails::ActiveRecord::Monetizable do
     describe "monetize" do
@@ -19,6 +23,10 @@ if defined? ActiveRecord
 
       it "should be inherited by subclasses" do
         expect(Sub.monetized_attributes).to eq(Product.monetized_attributes)
+      end
+
+      it "should be inherited by subclasses with new monetized attribute" do
+        expect(SubProduct.monetized_attributes).to eq(Product.monetized_attributes.merge(special_price: "special_price_cents"))
       end
 
       it "attaches a Money object to model field" do

--- a/spec/dummy/db/migrate/20150213234410_add_special_price_to_products.rb
+++ b/spec/dummy/db/migrate/20150213234410_add_special_price_to_products.rb
@@ -1,0 +1,5 @@
+class AddSpecialPriceToProducts < ActiveRecord::Migration
+  def change
+    add_column :products, :special_price_cents, :integer
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150126231442) do
+ActiveRecord::Schema.define(version: 20150213234410) do
 
   create_table "dummy_products", force: true do |t|
     t.string   "currency"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20150126231442) do
     t.integer  "restock_fee_cents"
     t.integer  "reduced_price_cents"
     t.string   "reduced_price_currency"
+    t.integer  "special_price_cents"
   end
 
   create_table "services", force: true do |t|


### PR DESCRIPTION
If both superclass and subclass uses monetize macros then .monetized_attributes has to merge recurrently @monetized_attributes from all superclasses.

[This commit](https://github.com/RubyMoney/money-rails/commit/8c2a2d45bb0f96f7b747c60de3dc4dab094835f5) has revealed this bug