### PR TITLE
Monetize test matcher improvement

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -43,8 +43,8 @@ module MoneyRails
             # if none of the previous is the case then use a default suffix
             if name
               name = name.to_s
-            elsif subunit_name =~ /#{MoneyRails::Configuration.amount_column[:postfix]}$/
-              name = subunit_name.sub(/#{MoneyRails::Configuration.amount_column[:postfix]}$/, "")
+            elsif has_prefix_or_postfix?(subunit_name)
+              name = cut_prefix_and_postfix(subunit_name)
             else
               # FIXME: provide a better default
               name = [subunit_name, "money"].join("_")
@@ -254,6 +254,17 @@ module MoneyRails
             end
           end
         end
+
+        private
+          def has_prefix_or_postfix?(name)
+            name =~ /#{MoneyRails::Configuration.amount_column[:postfix]}$/ ||
+              name =~ /^#{MoneyRails::Configuration.amount_column[:prefix]}/
+          end
+
+          def cut_prefix_and_postfix(name)
+            name.sub(/^#{MoneyRails::Configuration.amount_column[:prefix]}/, "").
+              sub(/#{MoneyRails::Configuration.amount_column[:postfix]}$/, "")
+          end
       end
     end
   end

--- a/lib/money-rails/test_helpers.rb
+++ b/lib/money-rails/test_helpers.rb
@@ -33,7 +33,7 @@ module MoneyRails
           @actual = actual.class.new
         end
 
-        @money_attribute = @as.presence || @attribute.to_s.sub(/_cents$/, "")
+        @money_attribute = @as.presence || attribute_accessor
         @money_attribute_setter = "#{@money_attribute}="
 
         object_responds_to_attributes? &&
@@ -95,6 +95,13 @@ module MoneyRails
         end
       end
 
+      def amount_column_config
+        MoneyRails::Configuration.amount_column
+      end
+
+      def attribute_accessor
+        @attribute.to_s.sub(/^#{amount_column_config[:prefix]}/, "").sub(/#{amount_column_config[:postfix]}$/, "")
+      end
     end
   end
 end

--- a/spec/dummy/app/models/good.rb
+++ b/spec/dummy/app/models/good.rb
@@ -1,0 +1,3 @@
+class Good < ActiveRecord::Base
+  monetize :some_prefix_price_pennies
+end

--- a/spec/dummy/db/migrate/20150217150423_create_goods.rb
+++ b/spec/dummy/db/migrate/20150217150423_create_goods.rb
@@ -1,0 +1,7 @@
+class CreateGoods < ActiveRecord::Migration
+  def change
+    create_table :goods do |t|
+      t.integer :some_prefix_price_pennies
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,13 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150213234410) do
+ActiveRecord::Schema.define(version: 20150217150423) do
 
   create_table "dummy_products", force: true do |t|
     t.string   "currency"
     t.integer  "price_cents"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "goods", force: true do |t|
+    t.integer "some_prefix_price_pennies"
   end
 
   create_table "products", force: true do |t|

--- a/spec/test_helpers_spec.rb
+++ b/spec/test_helpers_spec.rb
@@ -18,7 +18,7 @@ if defined? ActiveRecord
       shared_context "monetize matcher" do
 
         it "matches model attribute without a '_cents' suffix by default" do
-          is_expected.to monetize(:price_cents)
+          is_expected.to monetize(:price)
         end
 
         it "matches model attribute specified by :as chain" do
@@ -58,6 +58,22 @@ if defined? ActiveRecord
       describe "testing against the model class itself" do
         subject { Product }
         include_context "monetize matcher"
+      end
+
+      describe "testing smth other than cents as a default subunit" do
+        subject { Good }
+        before do
+          MoneyRails.default_currency = :gbp
+          MoneyRails.amount_column[:prefix] = 'some_prefix_'
+        end
+
+        it "matches model attribute with a suffix and with a prefix by default" do
+          is_expected.to monetize(:some_prefix_price_pennies)
+        end
+
+        it "matches model attribute without a '_pennies' suffix by default" do
+          is_expected.to monetize(:price)
+        end
       end
     end
   end


### PR DESCRIPTION
I had a trouble with test helper. It didn't allow me to use ruble as default currency because helper was designed to use hardcoded '_cents' postfix. So, I've fixed it.