### PR TITLE
Simplify validation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ are aggregate methods and you wish to avoid executing them on every record save.
 monetize :price_in_a_range_cents, :disable_validation => true
 ```
 
+You can also skip validations independently from each other by simply passing `false`
+to the validation you are willing to skip, like this:
+
+```ruby
+monetize :price_in_a_range_cents, :numericality => false
+```
+
 ### Mongoid 2.x and 3.x
 
 `Money` is available as a field type to supply during a field definition:

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -90,16 +90,20 @@ module MoneyRails
             if validation_enabled = MoneyRails.include_validations && !options[:disable_validation]
 
               # This is a validation for the subunit
-              validates subunit_name, {
-                :allow_nil => options[:allow_nil],
-                :numericality => options[:subunit_numericality] || true
-              }
+              if subunit_numericality = options.fetch(:subunit_numericality, true)
+                validates subunit_name, {
+                  :allow_nil => options[:allow_nil],
+                  :numericality => subunit_numericality
+                }
+              end
 
               # Allow only Money objects or Numeric values!
-              validates name.to_sym, {
-                :allow_nil => options[:allow_nil],
-                'money_rails/active_model/money' => options[:numericality] || true
-              }
+              if numericality = options.fetch(:numericality, true)
+                validates name.to_sym, {
+                  :allow_nil => options[:allow_nil],
+                  'money_rails/active_model/money' => numericality
+                }
+              end
             end
 
 

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -89,30 +89,16 @@ module MoneyRails
             #   monetize :price_in_a_range_cents, :disable_validation => true
             if validation_enabled = MoneyRails.include_validations && !options[:disable_validation]
 
-              subunit_validation_options =
-              unless options.has_key? :subunit_numericality
-                true
-              else
-                options[:subunit_numericality]
-              end
-
-              money_validation_options =
-              unless options.has_key? :numericality
-                true
-              else
-                options[:numericality]
-              end
-
               # This is a validation for the subunit
               validates subunit_name, {
                 :allow_nil => options[:allow_nil],
-                :numericality => subunit_validation_options
+                :numericality => options[:subunit_numericality] || true
               }
 
               # Allow only Money objects or Numeric values!
               validates name.to_sym, {
                 :allow_nil => options[:allow_nil],
-                'money_rails/active_model/money' => money_validation_options
+                'money_rails/active_model/money' => options[:numericality] || true
               }
             end
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -134,6 +134,16 @@ if defined? ActiveRecord
         expect(product.valid?).to be_truthy
       end
 
+      it "separately skips price validations" do
+        product.skip_validation_price = 'hundred thousands'
+        expect(product.save).to be_truthy
+      end
+
+      it "separately skips subunit validations" do
+        product.skip_validation_price_cents = 'ten million'
+        expect(product.save).to be_truthy
+      end
+
       it "fails validation with the proper error message if money value is invalid decimal" do
         product.price = "12.23.24"
         expect(product.save).to be_falsey

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -31,6 +31,9 @@ class Product < ActiveRecord::Base
     :message => "Must be greater than zero and less than $100"
   }
 
+  # Skip validations separately from each other
+  monetize :skip_validation_price_cents, subunit_numericality: false, numericality: false, allow_nil: true
+
   # Override default currency (EUR) with a specific one (CAD) for this field only, from a lambda
   monetize :lambda_price_cents, with_currency: ->(product) { Rails.configuration.lambda_test }, allow_nil: true
 

--- a/spec/dummy/db/migrate/20150303222230_add_skip_validation_price_cents_to_products.rb
+++ b/spec/dummy/db/migrate/20150303222230_add_skip_validation_price_cents_to_products.rb
@@ -1,0 +1,5 @@
+class AddSkipValidationPriceCentsToProducts < ActiveRecord::Migration
+  def change
+    add_column :products, :skip_validation_price_cents, :string
+  end
+end


### PR DESCRIPTION
Much simpler passing of validation options.

The only difference is that passing `subunit_numericality: false` won't work, but I'm not sure if this was ever a feature, because there's no docs or tests for this behaviour.