### PR TITLE
Always support t.monetize in migrations

### DIFF
--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -23,9 +23,8 @@ module MoneyRails
 
         require "money-rails/active_record/migration_extensions/options_extractor"
         %w{schema_statements table}.each do |file|
-          if postgresql_with_money
-            require "money-rails/active_record/migration_extensions/#{file}_pg_rails4"
-          else
+          require "money-rails/active_record/migration_extensions/#{file}_pg_rails4"
+          if !postgresql_with_money
             require "money-rails/active_record/migration_extensions/#{file}"
           end
         end


### PR DESCRIPTION
In mixed DB environments (in my case, sqlite3 for dev and postgres for production), migrations would work in one but not the other, which is not acceptable.

This change makes t.monetize/add_monetize/remove_monetize always available, and supports the 'money' version in non-postgres environments for backwards compatibility.