### PR TITLE
Include postgres specific code also when adaptor = postgis.

### DIFF
--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -1,6 +1,6 @@
 module MoneyRails
   class Hooks
-    PG_ADAPTERS = %w(activerecord-jdbcpostgresql-adapter postgresql)
+    PG_ADAPTERS = %w(activerecord-jdbcpostgresql-adapter postgresql postgis)
 
     def self.init
       # For Active Record


### PR DESCRIPTION
Allows the Posgres specific migrations to be used in Rails apps that use the ActiveRecord postgis adapter.