### PR TITLE
chore(add read only exception class)

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -5,6 +5,7 @@ require 'active_support/deprecation/reporting'
 module MoneyRails
   module ActiveRecord
     module Monetizable
+      class ReadOnlyCurrencyException < StandardError; end
       extend ActiveSupport::Concern
 
       module ClassMethods
@@ -177,7 +178,7 @@ module MoneyRails
               else
                 current_currency = public_send("currency_for_#{name}")
                 if money_currency && current_currency != money_currency.id
-                  raise "Can't change readonly currency '#{current_currency}' to '#{money_currency}' for field '#{name}'"
+                  raise ReadOnlyCurrencyException.new("Can't change readonly currency '#{current_currency}' to '#{money_currency}' for field '#{name}'")
                 end
               end
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -67,7 +67,7 @@ if defined? ActiveRecord
         product = Product.new
         expect {
           product.price = Money.new(10, "RUB")
-        }.to raise_error("Can't change readonly currency 'USD' to 'RUB' for field 'price'")
+        }.to raise_error(MoneyRails::ActiveRecord::Monetizable::ReadOnlyCurrencyException, "Can't change readonly currency 'USD' to 'RUB' for field 'price'")
       end
 
       it "raises an error if trying to create two attributes with the same name" do


### PR DESCRIPTION
We're finding that it would be really nice to be able to rescue the exception which occurs when a currency  that is readonly undergoes an attempted modification.  

For instance, user types "35EUR" into a field which is in dollars, we'd like to catch that exception and make it into a helpful user message.