### PR TITLE
validator was looking for monetizable_attributes using a symbol key

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -6,7 +6,7 @@ module MoneyRails
         @record = record
         @attr = attr
 
-        subunit_attr = @record.class.monetized_attributes[@attr.to_sym]
+        subunit_attr = @record.class.monetized_attributes[@attr.to_s]
 
         # WARNING: Currently this is only defined in ActiveRecord extension!
         before_type_cast = :"#{@attr}_money_before_type_cast"

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -22,12 +22,22 @@ if defined? ActiveRecord
         Service.create(:charge_cents => 2000, :discount_cents => 120)
       end
 
-      it "should be inherited by subclasses" do
-        expect(Sub.monetized_attributes).to eq(Product.monetized_attributes)
-      end
+      context 'monetized_attributes' do
+        it "should be inherited by subclasses" do
+          monetized_attributes = Sub.monetized_attributes
+          expect(monetized_attributes).to eq(Product.monetized_attributes)
+          monetized_attributes.keys.each do |key|
+            expect(key.is_a? String).to be_truthy
+          end
+        end
 
-      it "should be inherited by subclasses with new monetized attribute" do
-        expect(SubProduct.monetized_attributes).to eq(Product.monetized_attributes.merge(special_price: "special_price_cents"))
+        it "should be inherited by subclasses with new monetized attribute" do
+          monetized_attributes = SubProduct.monetized_attributes
+          expect(monetized_attributes).to eq(Product.monetized_attributes.merge(special_price: "special_price_cents"))
+          monetized_attributes.keys.each do |key|
+            expect(key.is_a? String).to be_truthy
+          end
+        end
       end
 
       it "attaches a Money object to model field" do

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 class Sub < Product; end
 
-class SubProduct < Product
-  monetize :special_price_cents
-end
-
 if defined? ActiveRecord
   describe MoneyRails::ActiveRecord::Monetizable do
     describe "monetize" do
@@ -23,16 +19,22 @@ if defined? ActiveRecord
       end
 
       context 'monetized_attributes' do
+
+        class InheritedMonetizeProduct < Product
+          monetize :special_price_cents
+        end
+
         it "should be inherited by subclasses" do
           assert_monetized_attributes(Sub.monetized_attributes, Product.monetized_attributes)
         end
 
         it "should be inherited by subclasses with new monetized attribute" do
-          assert_monetized_attributes(SubProduct.monetized_attributes, Product.monetized_attributes.merge(special_price: "special_price_cents"))
+          assert_monetized_attributes(InheritedMonetizeProduct.monetized_attributes, Product.monetized_attributes.merge(special_price: "special_price_cents"))
         end
 
         def assert_monetized_attributes(monetized_attributes, expected_attributes)
           expect(monetized_attributes).to include expected_attributes
+          expect(expected_attributes).to include monetized_attributes
           expect(monetized_attributes.size).to eql expected_attributes.size
           monetized_attributes.keys.each do |key|
             expect(key.is_a? String).to be_truthy

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -24,16 +24,16 @@ if defined? ActiveRecord
 
       context 'monetized_attributes' do
         it "should be inherited by subclasses" do
-          monetized_attributes = Sub.monetized_attributes
-          expect(monetized_attributes).to eq(Product.monetized_attributes)
-          monetized_attributes.keys.each do |key|
-            expect(key.is_a? String).to be_truthy
-          end
+          assert_monetized_attributes(Sub.monetized_attributes, Product.monetized_attributes)
         end
 
         it "should be inherited by subclasses with new monetized attribute" do
-          monetized_attributes = SubProduct.monetized_attributes
-          expect(monetized_attributes).to eq(Product.monetized_attributes.merge(special_price: "special_price_cents"))
+          assert_monetized_attributes(SubProduct.monetized_attributes, Product.monetized_attributes.merge(special_price: "special_price_cents"))
+        end
+
+        def assert_monetized_attributes(monetized_attributes, expected_attributes)
+          expect(monetized_attributes).to include expected_attributes
+          expect(monetized_attributes.size).to eql expected_attributes.size
           monetized_attributes.keys.each do |key|
             expect(key.is_a? String).to be_truthy
           end


### PR DESCRIPTION
The monetizable_attributes hash keys are all strings.  Asserted string key values in rspec and changed validator to look for a string key instead of symbol.