### PR TITLE
Include attribute in validation messages like Rails does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## master (next release)
 
- - Respect Money.use_i18n when validating.
+- Respect Money.use_i18n when validating.
+- Include attribute in validation messages like Rails does.
 
 ## 1.4.1
 

--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -75,10 +75,14 @@ module MoneyRails
       end
 
       def add_error
+        attr_name = @attr.to_s.tr('.', '_').humanize
+        attr_name = @record.class.human_attribute_name(@attr, default: attr_name)
+
         @record.errors.add(@attr, I18n.t('errors.messages.invalid_currency',
                                        { :thousands => thousands_separator,
                                          :decimal => decimal_mark,
-                                         :currency => abs_raw_value }))
+                                         :currency => abs_raw_value,
+                                         :attribute => attr_name }))
       end
 
       def decimal_pieces


### PR DESCRIPTION
Always having the attribute name anchored to the start of the validation message is quite restrictive so I redefine them in such a way that the attribute name can be placed anywhere. This relies on the `:attribute` key being set, which Rails does but MoneyRails doesn't.