### PR TITLE
Bump monetize for coinbase compatibility

### DIFF
--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_dependency "money",         "~> 6.5.0"
-  s.add_dependency "monetize",      "~> 1.1.0"
+  s.add_dependency "monetize",      "~> 1.3"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"
 

--- a/spec/dummy/app/models/priceable.rb
+++ b/spec/dummy/app/models/priceable.rb
@@ -2,7 +2,7 @@ if defined? Mongoid
   class Priceable
     include Mongoid::Document
 
-    field :price, :type => Money, :allow_nil => true
+    field :price, :type => Money
     field :price_hash, :type => Hash
   end
 end

--- a/spec/dummy/app/models/priceable.rb
+++ b/spec/dummy/app/models/priceable.rb
@@ -2,7 +2,7 @@ if defined? Mongoid
   class Priceable
     include Mongoid::Document
 
-    field :price, :type => Money
+    field :price, :type => Money, :allow_nil => true
     field :price_hash, :type => Hash
   end
 end


### PR DESCRIPTION
    money-rails (>= 1.4.1) ruby depends on
      monetize (~> 1.1.0) ruby

    coinbase (>= 2.2.1) ruby depends on
      monetize (~> 1.3) ruby