### PR TITLE
Respect raise_error_on_money_parsing before raising ReadOnlyCurrencyException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Respect Money.use_i18n when validating.
 - Include attribute in validation messages like Rails does.
+- Respect `raise_error_on_money_parsing` before raising a MoneyRails::ActiveRecord::Monetizable::ReadOnlyCurrencyException.
 
 ## 1.4.1
 

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -178,7 +178,8 @@ module MoneyRails
               else
                 current_currency = public_send("currency_for_#{name}")
                 if money_currency && current_currency != money_currency.id
-                  raise ReadOnlyCurrencyException.new("Can't change readonly currency '#{current_currency}' to '#{money_currency}' for field '#{name}'")
+                  raise ReadOnlyCurrencyException.new("Can't change readonly currency '#{current_currency}' to '#{money_currency}' for field '#{name}'") if MoneyRails.raise_error_on_money_parsing
+                  return nil
                 end
               end
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -75,13 +75,6 @@ if defined? ActiveRecord
         expect(product.price_cents).to eq(215)
       end
 
-      it "should raise error if can't change currency" do
-        product = Product.new
-        expect {
-          product.price = Money.new(10, "RUB")
-        }.to raise_error(MoneyRails::ActiveRecord::Monetizable::ReadOnlyCurrencyException, "Can't change readonly currency 'USD' to 'RUB' for field 'price'")
-      end
-
       it "raises an error if trying to create two attributes with the same name" do
         expect do
           class Product
@@ -132,11 +125,21 @@ if defined? ActiveRecord
         it "raises exception when a String value with hyphen is assigned" do
           expect { product.accessor_price = "10-235" }.to raise_error
         end
+
+        it "raises an exception if it can't change currency" do
+          expect {
+            Product.new.price = Money.new(10, "RUB")
+          }.to raise_error(MoneyRails::ActiveRecord::Monetizable::ReadOnlyCurrencyException, "Can't change readonly currency 'USD' to 'RUB' for field 'price'")
+        end
       end
 
       context "when MoneyRails.raise_error_on_money_parsing is false (default)" do
         it "does not raise exception when a String value with hyphen is assigned" do
           expect { product.accessor_price = "10-235" }.not_to raise_error
+        end
+
+        it "does not raise exception if it can't change currency" do
+          expect { Product.new.price = Money.new(10, "RUB") }.not_to raise_error
         end
       end
 


### PR DESCRIPTION
If the user gives a currency when they're not supposed to then it
makes sense to react as though the value is generally invalid.

I can merge this myself but I'd like some feedback first.