### PR TITLE
Docs: remove unnecessary step to use RSpec helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,9 +456,7 @@ So `humanized_money` will ignore `config.default_format = { no_cents_if_whole: f
 ### Testing
 
 If you use Rspec there is an test helper implementation.
-Just write `require "money-rails/test_helpers"` in spec_helper.rb and
-`include MoneyRails::TestHelpers` inside a describe block you want to
-use the helper.
+Just write `require "money-rails/test_helpers"` in spec_helper.rb.
 
 * the `monetize` matcher
 


### PR DESCRIPTION
`MoneyRails::TestHelpers` is included in RSpec examples automatically when `money-rails/test_helpers.rb` is required.