### PR TITLE
Prevent infinite loop when currency postfix is nil

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -197,7 +197,9 @@ module MoneyRails
             end
 
             define_method "currency_for_#{name}" do
-              instance_currency_name_with_postfix = "#{name}#{MoneyRails::Configuration.currency_column[:postfix]}"
+              if MoneyRails::Configuration.currency_column[:postfix].present?
+                instance_currency_name_with_postfix = "#{name}#{MoneyRails::Configuration.currency_column[:postfix]}"
+              end
 
               if instance_currency_name.present? && respond_to?(instance_currency_name) &&
                   Money::Currency.find(public_send(instance_currency_name))
@@ -207,8 +209,9 @@ module MoneyRails
                 Money::Currency.find(field_currency_name.call(self))
               elsif field_currency_name
                 Money::Currency.find(field_currency_name)
-              elsif respond_to?(instance_currency_name_with_postfix) &&
-                  Money::Currency.find(public_send(instance_currency_name_with_postfix))
+              elsif instance_currency_name_with_postfix.present? &&
+                     respond_to?(instance_currency_name_with_postfix) &&
+                     Money::Currency.find(public_send(instance_currency_name_with_postfix))
 
                 Money::Currency.find(public_send(instance_currency_name_with_postfix))
               elsif self.class.respond_to?(:currency)

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -668,6 +668,11 @@ if defined? ActiveRecord
           expect(transaction.total).to eq(Money.new(3000, :usd))
         end
 
+        it "allows currency column postfix to be blank" do
+          allow(MoneyRails::Configuration).to receive(:currency_column) { { postfix: nil, column_name: 'currency' } }
+          expect(dummy_product_with_nil_currency.price.currency).to eq(Money::Currency.find(:gbp))
+        end
+
         context "and an Italian locale" do
           around(:each) do |example|
             I18n.with_locale(:it) do


### PR DESCRIPTION
Fixes #286 (looping in @antstorm who made the original change)

When the currency column postfix is nil then `instance_currency_name_with_postfix` ends up being the same as the field name. 

Line 211 (old) was causing it to call the field name not the currency, creating an infinite loop between `currency_for_#{name}` and the field accessors.

I'm happy to add tests if someone can provide guidance on how to properly override the currency column name.

Note: This requires the instance currency field to be nil, otherwise line 211 (new) will return it. I'm not sure if it is desired behavior, but the default currency is not populated on instantiation, which allows this to happen.