### PR TITLE
Fix ruby-1.9.3 encoding issue

### DIFF
--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 class Sub < Product; end


### PR DESCRIPTION
Fix failing ruby-1.9.3 tests.

Issue was introduced by the commit pushed directly to master — https://github.com/RubyMoney/money-rails/commit/15d75d55211c715cccbb35541f3ca69c17a5a326

