### PR TITLE
Update monetize dependency

### DIFF
--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_dependency "money",         "~> 6.5.0"
-  s.add_dependency "monetize",      "~> 1.1.0"
+  s.add_dependency "monetize",      "~> 1.3.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"
 


### PR DESCRIPTION
Also, since `monetize` lives under the same roof, maybe it's worth omitting the patch level from the version dependency — `~> 1.3`. What do you guys think?