### PR TITLE
Checking for a specific error to be raised in tests

### DIFF
--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -82,7 +82,7 @@ if defined? ActiveRecord
           class Product
             monetize :discount, as: :price
           end
-        end.to raise_error
+        end.to raise_error ArgumentError
       end
 
       it "allows subclass to redefine attribute with the same name" do
@@ -125,7 +125,7 @@ if defined? ActiveRecord
         after { MoneyRails.raise_error_on_money_parsing = false }
 
         it "raises exception when a String value with hyphen is assigned" do
-          expect { product.accessor_price = "10-235" }.to raise_error
+          expect { product.accessor_price = "10-235" }.to raise_error ArgumentError
         end
 
         it "raises an exception if it can't change currency" do

--- a/spec/mongoid/four_spec.rb
+++ b/spec/mongoid/four_spec.rb
@@ -41,11 +41,11 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^4(.*)/
         after { MoneyRails.raise_error_on_money_parsing = false }
 
         it "raises exception if the mongoized value is a String with a hyphen" do
-          expect { priceable_from_string_with_hyphen }.to raise_error
+          expect { priceable_from_string_with_hyphen }.to raise_error ArgumentError
         end
 
         it "raises exception if the mongoized value is a String with an unknown currency" do
-          expect { priceable_from_string_with_unknown_currency }.to raise_error
+          expect { priceable_from_string_with_unknown_currency }.to raise_error ArgumentError
         end
       end
 

--- a/spec/mongoid/three_spec.rb
+++ b/spec/mongoid/three_spec.rb
@@ -41,11 +41,11 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
         after { MoneyRails.raise_error_on_money_parsing = false }
 
         it "raises exception if the mongoized value is a String with a hyphen" do
-          expect { priceable_from_string_with_hyphen }.to raise_error
+          expect { priceable_from_string_with_hyphen }.to raise_error ArgumentError
         end
 
         it "raises exception if the mongoized value is a String with an unknown currency" do
-          expect { priceable_from_string_with_unknown_currency }.to raise_error
+          expect { priceable_from_string_with_unknown_currency }.to raise_error ArgumentError
         end
       end
 

--- a/spec/mongoid/two_spec.rb
+++ b/spec/mongoid/two_spec.rb
@@ -45,7 +45,7 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^2(.*)/
         after { MoneyRails.raise_error_on_money_parsing = false }
 
         it "raises exception if the mongoized value is a String with a hyphen" do
-          expect { priceable_from_string_with_hyphen }.to raise_error
+          expect { priceable_from_string_with_hyphen }.to raise_error ArgumentError
         end
       end
 


### PR DESCRIPTION
Hi, 

In order for those tests to make more sense we need to check for a specific error. Otherwise any error that might occur inside of those blocks will cause the test to pass even `NoMethodError`.

This should also fix few warnings that appear while running the tests.