### PR TITLE
Fix RuboCop lint offenses

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ end
 
 APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)
 
-load 'rails/tasks/engine.rake' if File.exists?(APP_RAKEFILE)
+load 'rails/tasks/engine.rake' if File.exist?(APP_RAKEFILE)
 
 require 'rake'
 require 'rspec/core/rake_task'

--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -1,7 +1,7 @@
 module MoneyRails
   module ActiveModel
     class MoneyValidator < ::ActiveModel::Validations::NumericalityValidator
-      def validate_each(record, attr, value)
+      def validate_each(record, attr, _value)
         reset_memoized_variables!
         @record = record
         @attr = attr

--- a/lib/money-rails/active_record/migration_extensions/options_extractor.rb
+++ b/lib/money-rails/active_record/migration_extensions/options_extractor.rb
@@ -9,7 +9,7 @@ module MoneyRails
           default[:table_name] = table_name
 
           excluded_keys = [:amount, :currency, :type, :prefix, :postfix, :present, :column_name, :table_name]
-          default[:options] = default.except *excluded_keys
+          default[:options] = default.except(*excluded_keys)
 
           default.slice(:present, :table_name, :column_name, :type, :options).values
         end

--- a/lib/money-rails/active_record/migration_extensions/schema_statements_pg_rails4.rb
+++ b/lib/money-rails/active_record/migration_extensions/schema_statements_pg_rails4.rb
@@ -5,7 +5,7 @@ module MoneyRails
         def add_monetize(table_name, accessor, options={})
           [:amount, :currency].each do |attribute|
             column_present, *opts = OptionsExtractor.extract attribute, table_name, accessor, options
-            add_column *opts if column_present
+            add_column(*opts) if column_present
           end
         end
 

--- a/lib/money-rails/active_record/migration_extensions/table_pg_rails4.rb
+++ b/lib/money-rails/active_record/migration_extensions/table_pg_rails4.rb
@@ -5,7 +5,7 @@ module MoneyRails
         def monetize(accessor, options={})
           [:amount, :currency].each do |attribute|
             column_present, _, *opts = OptionsExtractor.extract attribute, :no_table, accessor, options
-            column *opts if column_present
+            column(*opts) if column_present
           end
         end
 

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -85,10 +85,10 @@ module MoneyRails
             #
             # To disable validation entirely, use :disable_validation, E.g:
             #   monetize :price_in_a_range_cents, :disable_validation => true
-            if validation_enabled = MoneyRails.include_validations && !options[:disable_validation]
+            if (validation_enabled = MoneyRails.include_validations && !options[:disable_validation])
 
               # This is a validation for the subunit
-              if subunit_numericality = options.fetch(:subunit_numericality, true)
+              if (subunit_numericality = options.fetch(:subunit_numericality, true))
                 validates subunit_name, {
                   :allow_nil => options[:allow_nil],
                   :numericality => subunit_numericality
@@ -96,7 +96,7 @@ module MoneyRails
               end
 
               # Allow only Money objects or Numeric values!
-              if numericality = options.fetch(:numericality, true)
+              if (numericality = options.fetch(:numericality, true))
                 validates name.to_sym, {
                   :allow_nil => options[:allow_nil],
                   'money_rails/active_model/money' => numericality

--- a/lib/money-rails/money.rb
+++ b/lib/money-rails/money.rb
@@ -11,7 +11,7 @@ class Money
       no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole,
       symbol: MoneyRails::Configuration.symbol,
       sign_before_symbol: MoneyRails::Configuration.sign_before_symbol
-    }.reject { |k,v| v.nil? }
+    }.reject { |_k, v| v.nil? }
 
     rules.reverse_merge!(defaults)
 

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -35,7 +35,7 @@ class Product < ActiveRecord::Base
   monetize :skip_validation_price_cents, subunit_numericality: false, numericality: false, allow_nil: true
 
   # Override default currency (EUR) with a specific one (CAD) for this field only, from a lambda
-  monetize :lambda_price_cents, with_currency: ->(product) { Rails.configuration.lambda_test }, allow_nil: true
+  monetize :lambda_price_cents, with_currency: ->(_product) { Rails.configuration.lambda_test }, allow_nil: true
 
   attr_accessor :accessor_price_cents
   monetize :accessor_price_cents, disable_validation: true

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -8,6 +8,6 @@ unless ENV['BUNDLE_GEMFILE']
 	ENV['BUNDLE_GEMFILE'] ||= gemfile
 end
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
 $:.unshift File.expand_path('../../../../lib', __FILE__)


### PR DESCRIPTION
Fix most of the offenses reported by RuboCop when run with the `--lint` option.

This was done so that when this gem is used while warnings are turned on (`RUBYOPT="-w"`), this gem produces fewer warnings.

The gem will still produce warnings about uninitialized instance variables being retrieved by monetizable.rb