### PR TITLE
Cents suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,23 +461,23 @@ Just write `require "money-rails/test_helpers"` in spec_helper.rb.
 * the `monetize` matcher
 
 ```ruby
-is_expected.to monetize(:price_cents)
+is_expected.to monetize(:price)
 ```
 This will ensure that a column called `price_cents` is being monetized.
 
 ```ruby
-is_expected.to monetize(:price_cents).allow_nil
+is_expected.to monetize(:price).allow_nil
 ```
 By using `allow_nil` you can specify money attributes that accept nil values.
 
 ```ruby
-is_expected.to monetize(:price_cents).as(:discount_value)
+is_expected.to monetize(:price).as(:discount_value)
 ```
 By using `as` chain you can specify the exact name to which a monetized
 column is being mapped.
 
 ```ruby
-is_expected.to monetize(:price_cents).with_currency(:gbp)
+is_expected.to monetize(:price).with_currency(:gbp)
 ```
 
 By using the `with_currency` chain you can specify the expected currency

--- a/spec/test_helpers_spec.rb
+++ b/spec/test_helpers_spec.rb
@@ -18,7 +18,7 @@ if defined? ActiveRecord
       shared_context "monetize matcher" do
 
         it "matches model attribute without a '_cents' suffix by default" do
-          is_expected.to monetize(:price_cents)
+          is_expected.to monetize(:price)
         end
 
         it "matches model attribute specified by :as chain" do
@@ -34,7 +34,7 @@ if defined? ActiveRecord
         end
 
         it "matches model attribute with currency specified by :with_currency chain" do
-          is_expected.to monetize(:bonus_cents).with_currency(:gbp)
+          is_expected.to monetize(:bonus).with_currency(:gbp)
         end
 
         it "does not match non existed attribute" do
@@ -42,11 +42,11 @@ if defined? ActiveRecord
         end
 
         it "does not match wrong currency iso" do
-          is_expected.not_to monetize(:bonus_cents).with_currency(:usd)
+          is_expected.not_to monetize(:bonus).with_currency(:usd)
         end
 
         it "does not match wrong money attribute name" do
-          is_expected.not_to monetize(:bonus_cents).as(:bonussss)
+          is_expected.not_to monetize(:bonus).as(:bonussss)
         end
       end
 


### PR DESCRIPTION
When using the `monetize` test helper one does not need to use the *_cents* suffix on the column to be monetized. Fixed the specs and the README to reflect that.