### PR TITLE
Updating gemspec to allow 6.X release of Money

### DIFF
--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_dependency "money",         "~> 6.5.0"
+  s.add_dependency "money",         "~> 6.5"
   s.add_dependency "monetize",      "~> 1.3.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -13,8 +13,8 @@ describe "configuration" do
     end
 
     it "adds exchange rates given in config initializer" do
-      expect(Money.us_dollar(100).exchange_to("CAD")).to eq(Money.new(124, "CAD"))
-      expect(Money.ca_dollar(100).exchange_to("USD")).to eq(Money.new(80, "USD"))
+      expect(Money.us_dollar(100).bank.get_rate('USD', 'CAD')).to eq(1.24515)
+      expect(Money.ca_dollar(100).bank.get_rate('CAD', 'USD')).to eq(0.803115)
     end
 
     it "sets no_cents_if_whole value for formatted output globally" do


### PR DESCRIPTION
References #356 - Relaxing the money dependency requirement here to allow any 6.X release of 'money'