### PR TITLE
Fixed typographical error, changed availabe to available in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ end
 Now ```product.discount``` and ```product.bonus``` will return a `Money`
 object using EUR as their currency, instead of the default USD.
 
-(This is not availabe in  Mongoid).
+(This is not available in  Mongoid).
 
 #### Attribute Currency (:with_currency)
 


### PR DESCRIPTION
RubyMoney, I've corrected a typographical error in the documentation of the [money-rails](https://github.com/RubyMoney/money-rails) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.