### PR TITLE
Fix validator invalid_currency error message look up path

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -77,11 +77,11 @@ module MoneyRails
         attr_name = @attr.to_s.tr('.', '_').humanize
         attr_name = @record.class.human_attribute_name(@attr, default: attr_name)
 
-        @record.errors.add(@attr, I18n.t('errors.messages.invalid_currency',
-                                       { :thousands => thousands_separator,
-                                         :decimal => decimal_mark,
-                                         :currency => abs_raw_value,
-                                         :attribute => attr_name }))
+        @record.errors.add(@attr, :invalid_currency,
+                           { :thousands => thousands_separator,
+                             :decimal => decimal_mark,
+                             :currency => abs_raw_value,
+                             :attribute => attr_name })
       end
 
       def decimal_pieces


### PR DESCRIPTION
Instead of hardcoding the I18n message path for `invalid_currency` we should let Rails (ActiveModel) look up the message in all namespaces. This allows for more flexible messages and customization of the message per model / attribute.

The lookup path and the namespaces are described in detail in the guide:
http://guides.rubyonrails.org/i18n.html#error-message-scopes

This change is backwards compatible for existing applications.