### PR TITLE
Relax monetize dependency; trust semver.

### DIFF
--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_dependency "money",         "~> 6.5"
-  s.add_dependency "monetize",      "~> 1.3.0"
+  s.add_dependency "monetize",      "~> 1.1.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"
 


### PR DESCRIPTION
Depend on monetize `~> 1.1`, not `~> 1.3.0`.

This was [recently bumped from "~> 1.1.0" to "~> 1.3.0"][bump] in order to permit newer versions of monetize, however that blocks older versions for no reason.

Setting "~> 1.1" rolls back the minimum version to what it was before, while permitting future v1.x releases (which should be compatible according to semver) and still blocking potentially incompatible v2.x releases.

- [ ] Revert to `monetize ~> 1.1.0` to ensure build/tests still pass.
- [ ] Relax to `monetize ~> 1.1` to permit future backwards-compatible 1.x versions.

[bump]: https://github.com/RubyMoney/money-rails/pull/364