### PR TITLE
Add example of raise_error_on_money_parsing to template

### DIFF
--- a/lib/generators/templates/money.rb
+++ b/lib/generators/templates/money.rb
@@ -67,4 +67,11 @@ MoneyRails.configure do |config|
   #   :symbol => nil,
   #   :sign_before_symbol => nil
   # }
+
+  # Set default raise_error_on_money_parsing option
+  # It will be raise error if assigned different currency
+  # The default value is false
+  #
+  # Example:
+  # config.raise_error_on_money_parsing = false
 end


### PR DESCRIPTION
I added example of raise_error_on_money_parsing to template.
Please comment about description if the description is not good.

Related. https://github.com/RubyMoney/money-rails/pull/332