### PR TITLE
failing spec for to_json stackoverflow issue

### DIFF
--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -120,6 +120,25 @@ if defined? ActiveRecord
         expect(product).to be_valid
       end
 
+      context 'when exchanging with custom store' do
+        before do
+          @bank = Money.default_bank
+          Money.default_bank = Money::Bank::VariableExchange.new(ExchangeRate)
+          Money.add_rate("USD", "EUR", 1)
+        end
+
+        after do
+          Money.default_bank = @bank
+        end
+
+        describe '#to_json' do
+          it 'should not explode' do
+            _ = product.price.exchange_to('EUR')
+            expect { product.price.to_json }.not_to raise_error
+          end
+        end
+      end
+
       context "when MoneyRails.raise_error_on_money_parsing is true" do
         before { MoneyRails.raise_error_on_money_parsing = true }
         after { MoneyRails.raise_error_on_money_parsing = false }

--- a/spec/dummy/app/models/exchange_rate.rb
+++ b/spec/dummy/app/models/exchange_rate.rb
@@ -1,0 +1,12 @@
+class ExchangeRate < ActiveRecord::Base
+  def self.get_rate(from_iso_code, to_iso_code)
+    rate = find_by(from: from_iso_code, to: to_iso_code)
+    rate.present? ? rate.rate : nil
+  end
+
+  def self.add_rate(from_iso_code, to_iso_code, rate)
+    exrate = find_or_initialize_by(from: from_iso_code, to: to_iso_code)
+    exrate.rate = rate
+    exrate.save!
+  end
+end

--- a/spec/dummy/db/migrate/20151117120330_create_exchange_rates.rb
+++ b/spec/dummy/db/migrate/20151117120330_create_exchange_rates.rb
@@ -1,0 +1,9 @@
+class CreateExchangeRates < ActiveRecord::Migration
+  def change
+    create_table :exchange_rates do |t|
+      t.string :from
+      t.string :to
+      t.float :rate
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,13 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151026220420) do
+ActiveRecord::Schema.define(version: 20151117120330) do
 
   create_table "dummy_products", force: :cascade do |t|
     t.string   "currency"
     t.integer  "price_cents"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "exchange_rates", force: :cascade do |t|
+    t.string "from"
+    t.string "to"
+    t.float  "rate"
   end
 
   create_table "products", force: :cascade do |t|


### PR DESCRIPTION
see #373 - this PR contains a minimal failing test.

It uses the most recent Money version (6.6) and the AR backed store is taken straight out of the [ruby-money doc](https://github.com/RubyMoney/money#exchange-rate-stores).
