### PR TITLE
Fix rails 5 deprecations

### DIFF
--- a/lib/money-rails/money.rb
+++ b/lib/money-rails/money.rb
@@ -2,8 +2,9 @@ require "active_support/core_ext/module/aliasing.rb"
 require "active_support/core_ext/hash/reverse_merge.rb"
 
 class Money
+  alias_method :orig_format, :format
 
-  def format_with_settings(*rules)
+  def format(*rules)
     rules = normalize_formatting_rules(rules)
 
     # Apply global defaults for money only for non-nil values
@@ -19,9 +20,7 @@ class Money
       rules.reverse_merge!(MoneyRails::Configuration.default_format)
     end
 
-    format_without_settings(rules)
+    orig_format(rules)
   end
-
-  alias_method_chain :format, :settings
 
 end

--- a/lib/money-rails/money.rb
+++ b/lib/money-rails/money.rb
@@ -1,9 +1,9 @@
 require "active_support/core_ext/module/aliasing.rb"
 require "active_support/core_ext/hash/reverse_merge.rb"
 
-module FormatWithSettings
+class Money
 
-  def format(*rules)
+  def format_with_settings(*rules)
     rules = normalize_formatting_rules(rules)
 
     # Apply global defaults for money only for non-nil values
@@ -19,9 +19,9 @@ module FormatWithSettings
       rules.reverse_merge!(MoneyRails::Configuration.default_format)
     end
 
-    super(rules)
+    format_without_settings(rules)
   end
 
-end
+  alias_method_chain :format, :settings
 
-Money.send(:prepend, FormatWithSettings)
+end

--- a/lib/money-rails/money.rb
+++ b/lib/money-rails/money.rb
@@ -1,9 +1,9 @@
 require "active_support/core_ext/module/aliasing.rb"
 require "active_support/core_ext/hash/reverse_merge.rb"
 
-class Money
+module FormatWithSettings
 
-  def format_with_settings(*rules)
+  def format(*rules)
     rules = normalize_formatting_rules(rules)
 
     # Apply global defaults for money only for non-nil values
@@ -19,9 +19,9 @@ class Money
       rules.reverse_merge!(MoneyRails::Configuration.default_format)
     end
 
-    format_without_settings(rules)
+    super(rules)
   end
 
-  alias_method_chain :format, :settings
-
 end
+
+Money.send(:prepend, FormatWithSettings)

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -15,7 +15,7 @@ Dummy::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching


### PR DESCRIPTION
In a Rails 5 project with money-rails the following deprecation warning is thrown:

```
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super.
```

Apparently [this deprecation](https://github.com/rails/rails/pull/19434) has been around for a while and I fixed it based on what I've learned from this article: [Rails 5, Module#prepend, and the End of `alias_method_chain`](http://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/).

I also updated the deprecated config option `serve_static_assets` in favour of `serve_static_files`.

Please note that `Module#prepend` was introduced in Ruby 2.0. [Rails 5 requires Ruby 2.2.2 or newer](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#ruby-versions) while Rails 4 prefers Ruby 2.0 but requires 1.9.3.

--

The tests are indeed failing on 1.9.3, but I'm not sure on how we could still support 1.9.3 while using `Module#prepend`.