### PR TITLE
Split monetize method apart

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -226,28 +226,7 @@ module MoneyRails
             end
 
             define_method "currency_for_#{name}" do
-              if MoneyRails::Configuration.currency_column[:postfix].present?
-                instance_currency_name_with_postfix = "#{name}#{MoneyRails::Configuration.currency_column[:postfix]}"
-              end
-
-              if instance_currency_name.present? && respond_to?(instance_currency_name) &&
-                  Money::Currency.find(public_send(instance_currency_name))
-
-                Money::Currency.find(public_send(instance_currency_name))
-              elsif field_currency_name.respond_to?(:call)
-                Money::Currency.find(field_currency_name.call(self))
-              elsif field_currency_name
-                Money::Currency.find(field_currency_name)
-              elsif instance_currency_name_with_postfix.present? &&
-                     respond_to?(instance_currency_name_with_postfix) &&
-                     Money::Currency.find(public_send(instance_currency_name_with_postfix))
-
-                Money::Currency.find(public_send(instance_currency_name_with_postfix))
-              elsif self.class.respond_to?(:currency)
-                self.class.currency
-              else
-                Money.default_currency
-              end
+              currency_for name, instance_currency_name, field_currency
             end
 
             attr_reader "#{name}_money_before_type_cast"
@@ -284,6 +263,31 @@ module MoneyRails
           end
 
           @monetized_attributes[name] = value
+        end
+      end
+
+      def currency_for(name, instance_currency_name, field_currency)
+        if MoneyRails::Configuration.currency_column[:postfix].present?
+          instance_currency_name_with_postfix = "#{name}#{MoneyRails::Configuration.currency_column[:postfix]}"
+        end
+
+        if instance_currency_name.present? && respond_to?(instance_currency_name) &&
+            Money::Currency.find(public_send(instance_currency_name))
+
+          Money::Currency.find(public_send(instance_currency_name))
+        elsif field_currency.respond_to?(:call)
+          Money::Currency.find(field_currency.call(self))
+        elsif field_currency
+          Money::Currency.find(field_currency)
+        elsif instance_currency_name_with_postfix.present? &&
+               respond_to?(instance_currency_name_with_postfix) &&
+               Money::Currency.find(public_send(instance_currency_name_with_postfix))
+
+          Money::Currency.find(public_send(instance_currency_name_with_postfix))
+        elsif self.class.respond_to?(:currency)
+          self.class.currency
+        else
+          Money.default_currency
         end
       end
     end

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -277,10 +277,6 @@ module MoneyRails
       end
 
       def currency_for(name, instance_currency_name, field_currency_name)
-        if MoneyRails::Configuration.currency_column[:postfix].present?
-          instance_currency_name_with_postfix = "#{name}#{MoneyRails::Configuration.currency_column[:postfix]}"
-        end
-
         if instance_currency_name.present? && respond_to?(instance_currency_name) &&
             Money::Currency.find(public_send(instance_currency_name))
 
@@ -289,11 +285,6 @@ module MoneyRails
           Money::Currency.find(field_currency_name.call(self))
         elsif field_currency_name
           Money::Currency.find(field_currency_name)
-        elsif instance_currency_name_with_postfix.present? &&
-               respond_to?(instance_currency_name_with_postfix) &&
-               Money::Currency.find(public_send(instance_currency_name_with_postfix))
-
-          Money::Currency.find(public_send(instance_currency_name_with_postfix))
         elsif self.class.respond_to?(:currency)
           self.class.currency
         else

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -116,68 +116,15 @@ module MoneyRails
               end
             end
 
+
+            # Getter for monetized attribute
             define_method name do |*args|
               read_monetized name, subunit_name, *args
             end
 
+            # Setter for monetized attribute
             define_method "#{name}=" do |value|
-
-              # Lets keep the before_type_cast value
-              instance_variable_set "@#{name}_money_before_type_cast", value
-
-              # Use nil or get a Money object
-              if options[:allow_nil] && value.blank?
-                money = nil
-              else
-                if value.is_a?(Money)
-                  money = value
-                else
-                  begin
-                    money = value.to_money(public_send("currency_for_#{name}"))
-                  rescue NoMethodError
-                    return nil
-                  rescue ArgumentError
-                    raise if MoneyRails.raise_error_on_money_parsing
-                    return nil
-                  rescue Money::Currency::UnknownCurrency
-                    raise if MoneyRails.raise_error_on_money_parsing
-                    return nil
-                  end
-                end
-              end
-
-              # Update cents
-              if !validation_enabled
-                # We haven't defined our own subunit writer, so we can invoke
-                # the regular writer, which works with store_accessors
-                public_send("#{subunit_name}=", money.try(:cents))
-              elsif self.class.respond_to?(:attribute_aliases) &&
-                  self.class.attribute_aliases.key?(subunit_name)
-                # If the attribute is aliased, make sure we write to the original
-                # attribute name or an error will be raised.
-                # (Note: 'attribute_aliases' doesn't exist in Rails 3.x, so we
-                # can't tell if the attribute was aliased.)
-                original_name = self.class.attribute_aliases[subunit_name.to_s]
-                write_attribute(original_name, money.try(:cents))
-              else
-                write_attribute(subunit_name, money.try(:cents))
-              end
-
-              money_currency = money.try(:currency)
-
-              # Update currency iso value if there is an instance currency attribute
-              if instance_currency_name.present? && respond_to?("#{instance_currency_name}=") && money_currency
-                public_send("#{instance_currency_name}=", money_currency.try(:iso_code))
-              else
-                current_currency = public_send("currency_for_#{name}")
-                if money_currency && current_currency != money_currency.id
-                  raise ReadOnlyCurrencyException.new("Can't change readonly currency '#{current_currency}' to '#{money_currency}' for field '#{name}'") if MoneyRails.raise_error_on_money_parsing
-                  return nil
-                end
-              end
-
-              # Save and return the new Money object
-              instance_variable_set "@#{name}", money
+              write_monetized name, subunit_name, value, validation_enabled, instance_currency_name, options
             end
 
             if validation_enabled
@@ -189,8 +136,9 @@ module MoneyRails
               end
             end
 
+            # Currency getter
             define_method "currency_for_#{name}" do
-              currency_for name, instance_currency_name, field_currency
+              currency_for name, instance_currency_name, field_currency_name
             end
 
             attr_reader "#{name}_money_before_type_cast"
@@ -269,7 +217,66 @@ module MoneyRails
         result
       end
 
-      def currency_for(name, instance_currency_name, field_currency)
+      def write_monetized(name, subunit_name, value, validation_enabled, instance_currency_name, options)
+        # Keep before_type_cast value as a reference to original input
+        instance_variable_set "@#{name}_money_before_type_cast", value
+
+        # Use nil or get a Money object
+        if options[:allow_nil] && value.blank?
+          money = nil
+        else
+          if value.is_a?(Money)
+            money = value
+          else
+            begin
+              money = value.to_money(public_send("currency_for_#{name}"))
+            rescue NoMethodError
+              return nil
+            rescue ArgumentError
+              raise if MoneyRails.raise_error_on_money_parsing
+              return nil
+            rescue Money::Currency::UnknownCurrency
+              raise if MoneyRails.raise_error_on_money_parsing
+              return nil
+            end
+          end
+        end
+
+        # Update cents
+        if !validation_enabled
+          # We haven't defined our own subunit writer, so we can invoke
+          # the regular writer, which works with store_accessors
+          public_send("#{subunit_name}=", money.try(:cents))
+        elsif self.class.respond_to?(:attribute_aliases) &&
+            self.class.attribute_aliases.key?(subunit_name)
+          # If the attribute is aliased, make sure we write to the original
+          # attribute name or an error will be raised.
+          # (Note: 'attribute_aliases' doesn't exist in Rails 3.x, so we
+          # can't tell if the attribute was aliased.)
+          original_name = self.class.attribute_aliases[subunit_name.to_s]
+          write_attribute(original_name, money.try(:cents))
+        else
+          write_attribute(subunit_name, money.try(:cents))
+        end
+
+        if money_currency = money.try(:currency)
+          # Update currency iso value if there is an instance currency attribute
+          if instance_currency_name.present? && respond_to?("#{instance_currency_name}=")
+            public_send("#{instance_currency_name}=", money_currency.iso_code)
+          else
+            current_currency = public_send("currency_for_#{name}")
+            if current_currency != money_currency.id
+              raise ReadOnlyCurrencyException.new("Can't change readonly currency '#{current_currency}' to '#{money_currency}' for field '#{name}'") if MoneyRails.raise_error_on_money_parsing
+              return nil
+            end
+          end
+        end
+
+        # Save and return the new Money object
+        instance_variable_set "@#{name}", money
+      end
+
+      def currency_for(name, instance_currency_name, field_currency_name)
         if MoneyRails::Configuration.currency_column[:postfix].present?
           instance_currency_name_with_postfix = "#{name}#{MoneyRails::Configuration.currency_column[:postfix]}"
         end
@@ -278,10 +285,10 @@ module MoneyRails
             Money::Currency.find(public_send(instance_currency_name))
 
           Money::Currency.find(public_send(instance_currency_name))
-        elsif field_currency.respond_to?(:call)
-          Money::Currency.find(field_currency.call(self))
-        elsif field_currency
-          Money::Currency.find(field_currency)
+        elsif field_currency_name.respond_to?(:call)
+          Money::Currency.find(field_currency_name.call(self))
+        elsif field_currency_name
+          Money::Currency.find(field_currency_name)
         elsif instance_currency_name_with_postfix.present? &&
                respond_to?(instance_currency_name_with_postfix) &&
                Money::Currency.find(public_send(instance_currency_name_with_postfix))

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -844,6 +844,129 @@ if defined? ActiveRecord
       end
     end
 
+    describe "#write_monetized" do
+      let(:value) { Money.new(1_000, 'LVL') }
+
+      it "sets monetized attribute's value to Money object" do
+        product.write_monetized :price, :price_cents, value, false, nil, {}
+
+        expect(product.price).to be_an_instance_of(Money)
+        expect(product.price_cents).to eq(value.cents)
+        # Because :price does not have a column for currency
+        expect(product.price.currency).to eq(Product.currency)
+      end
+
+      it "sets monetized attribute's value from a given Fixnum" do
+        product.write_monetized :price, :price_cents, 10, false, nil, {}
+
+        expect(product.price).to be_an_instance_of(Money)
+        expect(product.price_cents).to eq(1000)
+      end
+
+      it "sets monetized attribute's value from a given Float" do
+        product.write_monetized :price, :price_cents, 10.5, false, nil, {}
+
+        expect(product.price).to be_an_instance_of(Money)
+        expect(product.price_cents).to eq(1050)
+      end
+
+      it "resets monetized attribute when given blank input" do
+        product.write_monetized :price, :price_cents, nil, false, nil, { :allow_nil => true }
+
+        expect(product.price).to eq(nil)
+      end
+
+      it "sets monetized attribute to 0 when given a blank value" do
+        currency = product.price.currency
+        product.write_monetized :price, :price_cents, nil, false, nil, {}
+
+        expect(product.price.amount).to eq(0)
+        expect(product.price.currency).to eq(currency)
+      end
+
+      it "does not memoize monetized attribute's value if currency is read-only" do
+        product.write_monetized :price, :price_cents, value, false, nil, {}
+
+        price = product.instance_variable_get('@price')
+
+        expect(price).to be_an_instance_of(Money)
+        expect(price.amount).not_to eq(value.amount)
+      end
+
+      describe "instance_currency_name" do
+        it "updates instance_currency_name attribute" do
+          product.write_monetized :sale_price, :sale_price_amount, value, false, :sale_price_currency_code, {}
+
+          expect(product.sale_price).to eq(value)
+          expect(product.sale_price_currency_code).to eq('LVL')
+        end
+
+        it "memoizes monetized attribute's value with currency" do
+          product.write_monetized :sale_price, :sale_price_amount, value, false, :sale_price_currency_code, {}
+
+          expect(product.instance_variable_get('@sale_price')).to eq(value)
+        end
+
+        it "ignores empty instance_currency_name" do
+          product.write_monetized :sale_price, :sale_price_amount, value, false, '', {}
+
+          expect(product.sale_price.amount).to eq(value.amount)
+          expect(product.sale_price.currency).to eq(Product.currency)
+        end
+
+        it "ignores instance_currency_name that model does not respond to" do
+          product.write_monetized :sale_price, :sale_price_amount, value, false, :non_existing_currency, {}
+
+          expect(product.sale_price.amount).to eq(value.amount)
+          expect(product.sale_price.currency).to eq(Product.currency)
+        end
+      end
+
+      describe "error handling" do
+        let!(:old_price_value) { product.price }
+
+        it "ignores values that do not implement to_money method" do
+          product.write_monetized :price, :price_cents, [10], false, nil, {}
+
+          expect(product.price).to eq(old_price_value)
+        end
+
+        context "raise_error_on_money_parsing enabled" do
+          before { MoneyRails.raise_error_on_money_parsing = true }
+          after { MoneyRails.raise_error_on_money_parsing = false }
+
+          it "raises an ArgumentError when given an invalid value" do
+            expect {
+              product.write_monetized :price, :price_cents, '10-50', false, nil, {}
+            }.to raise_error(ArgumentError)
+          end
+
+          it "raises a Money::Currency::UnknownCurrency error when trying to set invalid currency" do
+            allow(product).to receive(:currency_for_price).and_return('INVALID_CURRENCY')
+            expect {
+              product.write_monetized :price, :price_cents, 10, false, nil, {}
+            }.to raise_error(Money::Currency::UnknownCurrency)
+          end
+        end
+
+        context "raise_error_on_money_parsing disabled" do
+          it "ignores when given invalid value" do
+            product.write_monetized :price, :price_cents, '10-50', false, nil, {}
+
+            expect(product.price).to eq(old_price_value)
+          end
+
+          it "raises a Money::Currency::UnknownCurrency error when trying to set invalid currency" do
+            allow(product).to receive(:currency_for_price).and_return('INVALID_CURRENCY')
+            product.write_monetized :price, :price_cents, 10, false, nil, {}
+
+            # Can not use public accessor here because currency_for_price is stubbed
+            expect(product.instance_variable_get('@price')).to eq(old_price_value)
+          end
+        end
+      end
+    end
+
     describe "#currency_for" do
       it "detects currency based on instance currency name" do
         product = Product.new(:sale_price_currency_code => 'CAD')

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -992,14 +992,6 @@ if defined? ActiveRecord
         expect(currency.iso_code).to eq('CAD')
       end
 
-      it "detects currency based on inferred currency field" do
-        product = Product.new(:reduced_price_currency => 'CAD')
-        currency = product.send(:currency_for, :reduced_price, nil, nil)
-
-        expect(currency).to be_an_instance_of(Money::Currency)
-        expect(currency.iso_code).to eq('CAD')
-      end
-
       it "falls back to a registered currency" do
         product = Product.new
         currency = product.send(:currency_for, :amount, nil, nil)

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -6,16 +6,16 @@ class Sub < Product; end
 
 if defined? ActiveRecord
   describe MoneyRails::ActiveRecord::Monetizable do
-    describe ".monetize" do
-      let(:product) do
-        Product.create(:price_cents => 3000, :discount => 150,
-                       :bonus_cents => 200, :optional_price => 100,
-                       :sale_price_amount => 1200, :delivery_fee_cents => 100,
-                       :restock_fee_cents => 2000,
-                       :reduced_price_cents => 1500, :reduced_price_currency => :lvl,
-                       :lambda_price_cents => 4000)
-      end
+    let(:product) do
+      Product.create(:price_cents => 3000, :discount => 150,
+                     :bonus_cents => 200, :optional_price => 100,
+                     :sale_price_amount => 1200, :delivery_fee_cents => 100,
+                     :restock_fee_cents => 2000,
+                     :reduced_price_cents => 1500, :reduced_price_currency => :lvl,
+                     :lambda_price_cents => 4000)
+    end
 
+    describe ".monetize" do
       let(:service) do
         Service.create(:charge_cents => 2000, :discount_cents => 120)
       end
@@ -394,21 +394,6 @@ if defined? ActiveRecord
       it "passes validation if there is a whitespace between the currency symbol and amount" do
         product.price = "$ 123,456.78"
         expect(product.save).to be_truthy
-      end
-
-      describe "with preserve_user_input set" do
-        around(:each) do |example|
-          old_value = MoneyRails::Configuration.preserve_user_input
-          MoneyRails::Configuration.preserve_user_input = true
-          example.run
-          MoneyRails::Configuration.preserve_user_input = false
-        end
-
-        it "preserves user input if validation fails" do
-          product.price = "14,0"
-          expect(product.save).to be_falsy
-          expect(product.price.to_s).to eq("14,0")
-        end
       end
 
       it "respects numericality validation when using update_attributes on money attribute" do
@@ -802,6 +787,60 @@ if defined? ActiveRecord
       it "attaches currency at model level" do
         expect(Product.currency).to eq(Money::Currency.find(:usd))
         expect(DummyProduct.currency).to eq(Money::Currency.find(:gbp))
+      end
+    end
+
+    describe "#read_monetized" do
+      it "returns monetized attribute's value" do
+        reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
+
+        expect(reduced_price).to be_an_instance_of(Money)
+        expect(reduced_price).to eq(Money.new(product.reduced_price_cents, product.reduced_price_currency))
+      end
+
+      context "memoize" do
+        it "memoizes monetized attribute's value" do
+          product.instance_variable_set '@reduced_price', nil
+          reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
+
+          expect(product.instance_variable_get('@reduced_price')).to eq(reduced_price)
+        end
+
+        it "resets memoized attribute's value if amount has changed" do
+          reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
+          product.reduced_price_cents = 100
+
+          expect(product.read_monetized(:reduced_price, :reduced_price_cents)).not_to eq(reduced_price)
+        end
+
+        it "resets memoized attribute's value if currency has changed" do
+          reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
+          product.reduced_price_currency = 'CAD'
+
+          expect(product.read_monetized(:reduced_price, :reduced_price_cents)).not_to eq(reduced_price)
+        end
+      end
+
+      context "with preserve_user_input set" do
+        around(:each) do |example|
+          MoneyRails::Configuration.preserve_user_input = true
+          example.run
+          MoneyRails::Configuration.preserve_user_input = false
+        end
+
+        it "has no effect if validation passes" do
+          product.price = '14'
+
+          expect(product.save).to be_truthy
+          expect(product.read_monetized(:price, :price_cents).to_s).to eq('14.00')
+        end
+
+        it "preserves user input if validation fails" do
+          product.price = '14,0'
+
+          expect(product.save).to be_falsy
+          expect(product.read_monetized(:price, :price_cents).to_s).to eq('14,0')
+        end
       end
     end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
Hey all,

This is my attempt at refactoring the monetize method by breaking down all dynamically generated methods into simple calls to static methods. I think that dynamic methods is a bad pattern that people keep abusing by adding more context-wrapped variables.

I've also included quite a lot of tests to make sure these newly introduced methods do exactly what we expect from them.