### PR TITLE
Raise ArgumentError when options[:as] attribute equals monetizable attribute

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -53,6 +53,13 @@ module MoneyRails
             # if none of the previous is the case then use a default suffix
             if name
               name = name.to_s
+
+              # Check if the options[:as] parameter is not the same as subunit_name
+              # which would result in stack overflow
+              if name == subunit_name
+                raise ArgumentError, "monetizable attribute name cannot be the same as options[:as] parameter"
+              end
+
             elsif subunit_name =~ /#{MoneyRails::Configuration.amount_column[:postfix]}$/
               name = subunit_name.sub(/#{MoneyRails::Configuration.amount_column[:postfix]}$/, "")
             else
@@ -103,7 +110,6 @@ module MoneyRails
                 }
               end
             end
-
 
             define_method name do |*args|
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -85,6 +85,14 @@ if defined? ActiveRecord
         end.to raise_error ArgumentError
       end
 
+      it "raises an error if Money object has the same attribute name as the monetizable attribute" do
+        expect do
+          class AnotherProduct < Product
+            monetize :price_cents, as: :price_cents
+          end
+        end.to raise_error ArgumentError
+      end
+
       it "allows subclass to redefine attribute with the same name" do
         class SubProduct < Product
           monetize :discount, as: :discount_price, with_currency: :gbp


### PR DESCRIPTION
Raise an ArgumentError when options[:as] parameter has the same name as monetizable attribute e.g:
`monetize :shipping_cost, as: :shipping_cost`
to escape `Stack overflow` error.
