### PR TITLE
make monetized_attributes a hash_with_indifferent_access

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -6,7 +6,7 @@ module MoneyRails
         @record = record
         @attr = attr
 
-        subunit_attr = @record.class.monetized_attributes[@attr.to_s]
+        subunit_attr = @record.class.monetized_attributes[@attr]
 
         # WARNING: Currently this is only defined in ActiveRecord extension!
         before_type_cast = :"#{@attr}_money_before_type_cast"

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -10,7 +10,7 @@ module MoneyRails
 
       module ClassMethods
         def monetized_attributes
-          monetized_attributes = @monetized_attributes || {}
+          monetized_attributes = @monetized_attributes || {}.with_indifferent_access
 
           if superclass.respond_to?(:monetized_attributes)
             monetized_attributes.merge(superclass.monetized_attributes)


### PR DESCRIPTION
`monetized_attributes` was getting created as a normal hash in one place and as a HWIA in another.  By making it always a HWIA, we don't care if the accessed attr in `validator` is a `symbol` or a `string.`

We noticed this when running our tests -- validation was failing because `@attr.to_s` was being used to look up the monetized_attribute but the key was a `symbol.`
