### PR TITLE
Fix ruby 1.9 support

### DIFF
--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "monetize",      "~> 1.4.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"
+  s.add_dependency "mime-types",    "< 3" if RUBY_VERSION < '2.0' # mime-types > 3 depends on mime-types-data, which doesn't support ruby 1.9
 
   s.add_development_dependency "rails",       ">= 3.0"
   s.add_development_dependency "rspec-rails", "~> 3.0"


### PR DESCRIPTION
With the release of rails `4.2.6`, `mail` (which is a dependency of `actionmailer`) has now a looser dependency on `mime-types` (`< 4`), causing issues with ruby 1.9 (not supported by `mime-types >= 3`).

Because of loose dependency of `mail`, this PR locks down `mime-types` to `< 3` for ruby 1.9.