### PR TITLE
Update inferred currency column. Fixes #432. Fixes #408

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -32,19 +32,6 @@ module MoneyRails
                                               ":with_currency or :with_model_currency")
             end
 
-            # Optional accessor to be run on an instance to detect currency
-            instance_currency_name = options[:with_model_currency] ||
-              options[:model_currency] ||
-              MoneyRails::Configuration.currency_column[:column_name]
-
-            instance_currency_name = instance_currency_name &&
-              instance_currency_name.to_s
-
-            # This attribute allows per column currency values
-            # Overrides row and default currency
-            field_currency_name = options[:with_currency] ||
-              options[:field_currency] || nil
-
             name = options[:as] || options[:target_name] || nil
 
             # Form target name for the money backed ActiveModel field:
@@ -66,6 +53,23 @@ module MoneyRails
               # FIXME: provide a better default
               name = [subunit_name, "money"].join("_")
             end
+
+            # Optional accessor to be run on an instance to detect currency
+            instance_currency_name = options[:with_model_currency] ||
+              options[:model_currency] ||
+              MoneyRails::Configuration.currency_column[:column_name]
+
+            # Infer currency column from name and postfix
+            if !instance_currency_name && MoneyRails::Configuration.currency_column[:postfix].present?
+              instance_currency_name = "#{name}#{MoneyRails::Configuration.currency_column[:postfix]}"
+            end
+
+            instance_currency_name = instance_currency_name && instance_currency_name.to_s
+
+            # This attribute allows per column currency values
+            # Overrides row and default currency
+            field_currency_name = options[:with_currency] ||
+              options[:field_currency] || nil
 
             # Create a reverse mapping of the monetized attributes
             track_monetized_attribute name, subunit_name

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -698,6 +698,14 @@ if defined? ActiveRecord
           expect(dummy_product_with_nil_currency.price.currency).to eq(Money::Currency.find(:gbp))
         end
 
+        it "updates inferred currency column based on currency column postfix" do
+          product.reduced_price = Money.new(999_00, 'CAD')
+          product.save
+
+          expect(product.reduced_price_cents).to eq(999_00)
+          expect(product.reduced_price_currency).to eq('CAD')
+        end
+
         context "and field with allow_nil: true" do
           it "doesn't set currency to nil when setting the field to nil" do
             t = Transaction.new(:amount_cents => 2500, :currency => "CAD")


### PR DESCRIPTION
This will use `#{name}_currency` (by default, or `currency_column[:postfix]`) column to persist currency, which so far has only been used for detecting currency and had to be updated manually.

This should fix issues #432 and #408 