### PR TITLE
Add money field for rails_admin

### DIFF
--- a/lib/money-rails.rb
+++ b/lib/money-rails.rb
@@ -14,3 +14,7 @@ if defined? Rails
   require "money-rails/railtie"
   require "money-rails/engine"
 end
+
+if Object.const_defined?("RailsAdmin")
+  require "money-rails/rails_admin"
+end

--- a/lib/money-rails/rails_admin.rb
+++ b/lib/money-rails/rails_admin.rb
@@ -1,0 +1,21 @@
+require 'rails_admin/config/fields'
+require 'rails_admin/config/fields/types/integer'
+require 'money-rails/helpers/action_view_extension'
+
+include MoneyRails::ActionViewExtension
+
+module RailsAdmin
+  module Config
+    module Fields
+      module Types
+        class Money < RailsAdmin::Config::Fields::Types::Integer
+          RailsAdmin::Config::Fields::Types::register(self)
+
+          register_instance_option :pretty_value do
+            humanized_money_with_symbol(value)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #216 

Unfortunately, you need to specify ```:money``` field in your model config:
```ruby
rails_admin do
  field :price, :money
end
```

That's due to rails_admin implementation.