### PR TITLE
Raise an error when unable to infer a name for the monetizable attribute. Fix #413

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -50,8 +50,9 @@ module MoneyRails
             elsif subunit_name =~ /#{MoneyRails::Configuration.amount_column[:postfix]}$/
               name = subunit_name.sub(/#{MoneyRails::Configuration.amount_column[:postfix]}$/, "")
             else
-              # FIXME: provide a better default
-              name = [subunit_name, "money"].join("_")
+              raise ArgumentError, "Unable to infer the name of the monetizable attribute for '#{subunit_name}'. " \
+                                   "Expected amount column postfix is '#{MoneyRails::Configuration.amount_column[:postfix]}'. " \
+                                   "Use :as option to explicitly specify the name or change the amount column postfix in the initializer."
             end
 
             # Optional accessor to be run on an instance to detect currency

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -101,6 +101,19 @@ if defined? ActiveRecord
         end.to raise_error ArgumentError
       end
 
+      it "raises an error when unable to infer attribute name" do
+        old_postfix = MoneyRails::Configuration.amount_column[:postfix]
+        MoneyRails::Configuration.amount_column[:postfix] = '_pennies'
+
+        expect do
+          class AnotherProduct < Product
+            monetize :price_cents
+          end
+        end.to raise_error ArgumentError
+
+        MoneyRails::Configuration.amount_column[:postfix] = old_postfix
+      end
+
       it "allows subclass to redefine attribute with the same name" do
         class SubProduct < Product
           monetize :discount, as: :discount_price, with_currency: :gbp


### PR DESCRIPTION
It is really confusing when due to a different default currency money will try to infer name based on different amount column postfix (i.e. `_pennies` for GBP). When trying to monetize `price_cents`, default name in that case would be `price_cents_money` and it will just crash with UnknownMethod when accessing `price`.

This change will raise an error in such a case and will provide an explanation on how to fix it.