### PR TITLE
Revert #411

### DIFF
--- a/lib/money-rails/helpers/action_view_extension.rb
+++ b/lib/money-rails/helpers/action_view_extension.rb
@@ -11,23 +11,19 @@ module MoneyRails
         options = { :symbol => options }
       end
 
-      unless value.is_a?(Money)
-        if value.respond_to?(:to_money)
-          value = value.to_money
-        else
-          return ''
-        end
-      end
-
       options = {
-        :no_cents_if_whole   => MoneyRails::Configuration.no_cents_if_whole.nil? ? true : MoneyRails::Configuration.no_cents_if_whole,
-        :symbol              => false,
-        :decimal_mark        => value.currency.decimal_mark,
-        :thousands_separator => value.currency.thousands_separator
+        :no_cents_if_whole => MoneyRails::Configuration.no_cents_if_whole.nil? ? true : MoneyRails::Configuration.no_cents_if_whole,
+        :symbol => false
       }.merge(options)
       options.delete(:symbol) if options[:disambiguate]
 
-      value.format(options)
+      if value.is_a?(Money)
+        value.format(options)
+      elsif value.respond_to?(:to_money)
+        value.to_money.format(options)
+      else
+        ""
+      end
     end
 
     def humanized_money_with_symbol(value, options={})

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe 'MoneyRails::ActionViewExtension', :type => :helper do
@@ -46,18 +44,10 @@ describe 'MoneyRails::ActionViewExtension', :type => :helper do
   end
 
   describe '#humanized_money_with_symbol' do
-    let(:amount) { 125_010 }
-    let(:expected_values) { {
-      :eur => '€1.250,10',
-      :usd => '$1,250.10',
-      :sek => '1 250,10 kr'
-    } }
-
-    it 'returns the correctly formatted values' do
-      expected_values.each do |currency, result|
-        expect(helper.humanized_money_with_symbol(Money.new(amount, currency))).to eq result
-      end
-    end
+    subject { helper.humanized_money_with_symbol Money.new(12500) }
+    it { is_expected.to be_a String }
+    it { is_expected.not_to include Money.default_currency.decimal_mark }
+    it { is_expected.to include Money.default_currency.symbol }
   end
 
   describe '#money_without_cents' do
@@ -96,7 +86,7 @@ describe 'MoneyRails::ActionViewExtension', :type => :helper do
       describe '#humanized_money' do
         subject { helper.humanized_money Money.new(12500) }
         it { is_expected.to be_a String }
-        it { is_expected.to include Money.default_currency.decimal_mark }
+        it { is_expected.not_to include Money.default_currency.decimal_mark }
         it { is_expected.not_to include Money.default_currency.symbol }
         it { is_expected.to include "00" }
       end
@@ -104,7 +94,7 @@ describe 'MoneyRails::ActionViewExtension', :type => :helper do
       describe '#humanized_money_with_symbol' do
         subject { helper.humanized_money_with_symbol Money.new(12500) }
         it { is_expected.to be_a String }
-        it { is_expected.to include Money.default_currency.decimal_mark }
+        it { is_expected.not_to include Money.default_currency.decimal_mark }
         it { is_expected.to include Money.default_currency.symbol }
         it { is_expected.to include "00" }
       end


### PR DESCRIPTION
I completely disagree with #411 and propose to revert it.

The formatting of the number depends on the language in the real world,not on the currency. The best example is the Euro, where it previously enforce the German format on the entire Euro zone. France, Italy and Spain for example write `1 234,56 €`, not `1.234.56 €`. And I think, English speaking countries would expect `1,234.56 €`, even though there is no English speaking country who uses the Euro. In return, we Germans also write `$ 1.234,56`, not `$ 1,234.56`. As I see it, you can't show currencies on a site in German and French now without always passing the params anymore.

The question is, whether the currency should have this information at all. Even though it comes from `money`, which might be used without `i18n`, I think it should be remove for the same reason.

/cc @manuelmeurer, @semmons99, @antstorm