### PR TITLE
Do not convert Mongoid money fields from nil to zero.

### DIFF
--- a/lib/money-rails/mongoid/money.rb
+++ b/lib/money-rails/mongoid/money.rb
@@ -37,6 +37,7 @@ class Money
           object.symbolize_keys!
         end
         ::Money.new(object[:cents], object[:currency_iso]).mongoize
+      when object.nil? then nil
       when object.respond_to?(:to_money) then
         begin
           object.to_money.mongoize

--- a/lib/money-rails/mongoid/two.rb
+++ b/lib/money-rails/mongoid/two.rb
@@ -21,6 +21,7 @@ class Money
         :cents        => object.cents.is_a?(BigDecimal) ? object.cents.to_s : object.cents,
         :currency_iso => object.currency.iso_code
       }
+    when object.nil? then nil
     when object.respond_to?(:to_money)
       begin
         serialize(object.to_money)

--- a/spec/mongoid/four_spec.rb
+++ b/spec/mongoid/four_spec.rb
@@ -4,6 +4,7 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^4(.*)/
 
   describe Money do
     let!(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
+    let!(:priceable_from_nil) { Priceable.create(:price => nil) }
     let!(:priceable_from_num) { Priceable.create(:price => 1) }
     let!(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
     let!(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
@@ -21,6 +22,10 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^4(.*)/
     }
 
     context "mongoize" do
+      it "correctly mongoizes nil to nil" do
+        expect(priceable_from_nil.price).to be_nil
+      end
+
       it "correctly mongoizes a Money object to a hash of cents and currency" do
         expect(priceable.price.cents).to eq(100)
         expect(priceable.price.currency).to eq(Money::Currency.find('EUR'))
@@ -97,11 +102,11 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^4(.*)/
       it { is_expected.to be_an_instance_of(Money) }
       it { is_expected.to eq(Money.new(100, 'EUR')) }
 
-      it "returns 0 cents in default_currency if a nil value was stored" do
+      it "returns nil if a nil value was stored" do
         nil_priceable = Priceable.create(price: nil)
-        expect(nil_priceable.price.cents).to eq(0)
-        expect(nil_priceable.price.currency).to eq(Money.default_currency)
+        expect(nil_priceable.price).to be_nil
       end
+
       it 'returns nil if an unknown value was stored' do
         zero_priceable = Priceable.create(:price => [])
         expect(zero_priceable.price).to be_nil

--- a/spec/mongoid/three_spec.rb
+++ b/spec/mongoid/three_spec.rb
@@ -4,6 +4,7 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
 
   describe Money do
     let!(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
+    let!(:priceable_from_nil) { Priceable.create(:price => nil) }
     let!(:priceable_from_num) { Priceable.create(:price => 1) }
     let!(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
     let!(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
@@ -21,6 +22,10 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
     }
 
     context "mongoize" do
+      it "mongoizes correctly nil to nil" do
+        expect(priceable_from_nil.price).to be_nil
+      end
+
       it "mongoizes correctly a Money object to a hash of cents and currency" do
         expect(priceable.price.cents).to eq(100)
         expect(priceable.price.currency).to eq(Money::Currency.find('EUR'))
@@ -96,11 +101,12 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
       subject { Priceable.first.price }
       it { is_expected.to be_an_instance_of(Money) }
       it { is_expected.to eq(Money.new(100, 'EUR')) }
-      it "returns 0 cents in default_currency if a nil value was stored" do
+
+      it "returns nil if a nil value was stored" do
         nil_priceable = Priceable.create(price: nil)
-        expect(nil_priceable.price.cents).to eq(0)
-        expect(nil_priceable.price.currency).to eq(Money.default_currency)
+        expect(nil_priceable.price).to be_nil
       end
+
       it 'returns nil if an unknown value was stored' do
         zero_priceable = Priceable.create(:price => [])
         expect(zero_priceable.price).to be_nil

--- a/spec/mongoid/two_spec.rb
+++ b/spec/mongoid/two_spec.rb
@@ -4,12 +4,17 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^2(.*)/
 
   describe Money do
     let(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
+    let(:priceable_from_nil) { Priceable.create(:price => nil) }
     let(:priceable_from_num) { Priceable.create(:price => 1) }
     let(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
     let(:priceable_with_infinite_precision) { Priceable.create(:price => Money.new(BigDecimal.new('100.1'), 'EUR')) }
     let(:priceable_from_string_with_hyphen) { Priceable.create(:price => '1-2 EUR' )}
 
     context "serialize" do
+      it "mongoizes correctly nil to nil" do
+        expect(priceable_from_nil.price).to be_nil
+      end
+
       it "serializes correctly a Money object to a hash of cents and currency" do
         expect(priceable.price.cents).to eq(100)
         expect(priceable.price.currency).to eq(Money::Currency.find('EUR'))
@@ -60,11 +65,12 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^2(.*)/
       subject { priceable.price }
       it { is_expected.to be_an_instance_of(Money) }
       it { is_expected.to eq(Money.new(100, 'EUR')) }
-      it "returns 0 cents in default_currency if a nil value was stored" do
+
+      it "returns nil if a nil value was stored" do
         nil_priceable = Priceable.create(price: nil)
-        expect(nil_priceable.price.cents).to eq(0)
-        expect(nil_priceable.price.currency).to eq(Money.default_currency)
+        expect(nil_priceable.price).to be_nil
       end
+
       it 'returns nil if an unknown value was stored' do
         zero_priceable = Priceable.create(:price => [])
         expect(zero_priceable.price).to be_nil


### PR DESCRIPTION
[This change](https://github.com/RubyMoney/monetize/pull/42) to monetize 1.3.0 extended NilClass to respond to `:to_money` and return a 0-valued Money object.

This is a breaking change in money-rails, as documented in https://github.com/RubyMoney/money-rails/issues/384. Whenever assigning a Mongoid Money field to nil, it will convert it to a 0-valued Money object. The behavior of money-rails was explicitly changed in https://github.com/RubyMoney/money-rails/pull/364.

For the record, I think the change to `monetize` should get reverted, but at least making `money-rails` preserve its old behavior is essential.