### PR TITLE
Update monetize dependency

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -232,11 +232,11 @@ module MoneyRails
               money = value.to_money(public_send("currency_for_#{name}"))
             rescue NoMethodError
               return nil
-            rescue ArgumentError
+            rescue ArgumentError, Money::Currency::UnknownCurrency
               raise if MoneyRails.raise_error_on_money_parsing
               return nil
-            rescue Money::Currency::UnknownCurrency
-              raise if MoneyRails.raise_error_on_money_parsing
+            rescue Monetize::ParseError => e
+              raise ArgumentError, e.message if MoneyRails.raise_error_on_money_parsing
               return nil
             end
           end

--- a/lib/money-rails/mongoid/money.rb
+++ b/lib/money-rails/mongoid/money.rb
@@ -44,6 +44,9 @@ class Money
         rescue ArgumentError, Money::Currency::UnknownCurrency
           raise if MoneyRails.raise_error_on_money_parsing
           nil
+        rescue Monetize::ParseError => e
+          raise ArgumentError, e.message if MoneyRails.raise_error_on_money_parsing
+          nil
         end
       else object
       end

--- a/lib/money-rails/mongoid/two.rb
+++ b/lib/money-rails/mongoid/two.rb
@@ -28,6 +28,9 @@ class Money
       rescue ArgumentError
         raise if MoneyRails.raise_error_on_money_parsing
         nil
+      rescue Monetize::ParseError => e
+        raise ArgumentError, e.message if MoneyRails.raise_error_on_money_parsing
+        nil
       end
     else nil
     end

--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_dependency "money",         "~> 6.7"
-  s.add_dependency "monetize",      "~> 1.4.0"
+  s.add_dependency "money",         "~> 6.7.1"
+  s.add_dependency "monetize",      "~> 1.5.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"
   s.add_dependency "mime-types",    "< 3" if RUBY_VERSION < '2.0' # mime-types > 3 depends on mime-types-data, which doesn't support ruby 1.9


### PR DESCRIPTION
Update monetize from `1.4.0` to `1.5.0`.

The re-raise of argument errors is to maintain current behaviour after this change: https://github.com/RubyMoney/monetize/commit/c6b0bc9dae4ff55d35d7bc289580ad45161f7df9
