### PR TITLE
Ruby 2.4.0 support and upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,6 @@ matrix:
       gemfile: gemfiles/rails4.gemfile
     - rvm: 2.4.0
       gemfile: gemfiles/rails41.gemfile
-    - rvm: 2.4.0
-      gemfile: gemfiles/rails42.gemfile
 notifications:
   recipients:
     - andreas@aloop.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,20 @@ matrix:
       gemfile: gemfiles/rails50.gemfile
     - rvm: 2.1.8
       gemfile: gemfiles/rails50.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/mongoid2.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/mongoid3.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/mongoid4.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails3.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails4.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails41.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails42.gemfile
 notifications:
   recipients:
     - andreas@aloop.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,6 @@ gemfile:
   - gemfiles/rails50.gemfile
 matrix:
   exclude:
-    - rvm: 1.9.2
-      gemfile: gemfiles/mongoid3.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails4.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails50.gemfile
     - rvm: 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.8.0
+
+- Ruby 2.4 support
+- Upgrade Money dependency from 6.7 to 6.8.1
+- Upgrade Monetize dependency from 1.4.0 to 1.6.0
+
 ## 1.7.0
 
 - Rails 5 support

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
+gem 'nokogiri', '~> 1.6.8.1'
 
 platforms :jruby do
   gem "activerecord-jdbc-adapter"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 4.2.0'
+gem 'rails', github: 'rails/rails', branch: '4-2-stable'
 gem 'nokogiri', '~> 1.6.8.1'
 
 platforms :jruby do

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -232,10 +232,7 @@ module MoneyRails
               money = value.to_money(public_send("currency_for_#{name}"))
             rescue NoMethodError
               return nil
-            rescue ArgumentError
-              raise if MoneyRails.raise_error_on_money_parsing
-              return nil
-            rescue Money::Currency::UnknownCurrency
+            rescue Money::Currency::UnknownCurrency, Monetize::ParseError
               raise if MoneyRails.raise_error_on_money_parsing
               return nil
             end

--- a/lib/money-rails/mongoid/money.rb
+++ b/lib/money-rails/mongoid/money.rb
@@ -41,7 +41,7 @@ class Money
       when object.respond_to?(:to_money) then
         begin
           object.to_money.mongoize
-        rescue ArgumentError, Money::Currency::UnknownCurrency
+        rescue Money::Currency::UnknownCurrency, Monetize::ParseError
           raise if MoneyRails.raise_error_on_money_parsing
           nil
         end

--- a/lib/money-rails/mongoid/two.rb
+++ b/lib/money-rails/mongoid/two.rb
@@ -25,7 +25,7 @@ class Money
     when object.respond_to?(:to_money)
       begin
         serialize(object.to_money)
-      rescue ArgumentError
+      rescue Monetize::ParseError
         raise if MoneyRails.raise_error_on_money_parsing
         nil
       end

--- a/lib/money-rails/version.rb
+++ b/lib/money-rails/version.rb
@@ -1,3 +1,3 @@
 module MoneyRails
-  VERSION = '1.7.0'
+  VERSION = '1.8.0'
 end

--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_dependency "money",         "~> 6.7"
-  s.add_dependency "monetize",      "~> 1.4.0"
+  s.add_dependency "money",         "~> 6.8.1"
+  s.add_dependency "monetize",      "~> 1.6.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"
   s.add_dependency "mime-types",    "< 3" if RUBY_VERSION < '2.0' # mime-types > 3 depends on mime-types-data, which doesn't support ruby 1.9

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -154,7 +154,7 @@ if defined? ActiveRecord
         after { MoneyRails.raise_error_on_money_parsing = false }
 
         it "raises exception when a String value with hyphen is assigned" do
-          expect { product.accessor_price = "10-235" }.to raise_error ArgumentError
+          expect { product.accessor_price = "10-235" }.to raise_error Monetize::ParseError
         end
 
         it "raises an exception if it can't change currency" do
@@ -935,10 +935,10 @@ if defined? ActiveRecord
           before { MoneyRails.raise_error_on_money_parsing = true }
           after { MoneyRails.raise_error_on_money_parsing = false }
 
-          it "raises an ArgumentError when given an invalid value" do
+          it "raises a Monetize::ParseError when given an invalid value" do
             expect {
               product.write_monetized :price, :price_cents, '10-50', false, nil, {}
-            }.to raise_error(ArgumentError)
+            }.to raise_error(Monetize::ParseError)
           end
 
           it "raises a Money::Currency::UnknownCurrency error when trying to set invalid currency" do

--- a/spec/mongoid/five_spec.rb
+++ b/spec/mongoid/five_spec.rb
@@ -41,11 +41,11 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^5(.*)/
         after { MoneyRails.raise_error_on_money_parsing = false }
 
         it "raises exception if the mongoized value is a String with a hyphen" do
-          expect { priceable_from_string_with_hyphen }.to raise_error ArgumentError
+          expect { priceable_from_string_with_hyphen }.to raise_error Monetize::ParseError
         end
 
         it "raises exception if the mongoized value is a String with an unknown currency" do
-          expect { priceable_from_string_with_unknown_currency }.to raise_error ArgumentError
+          expect { priceable_from_string_with_unknown_currency }.to raise_error Monetize::ParseError
         end
       end
 

--- a/spec/mongoid/four_spec.rb
+++ b/spec/mongoid/four_spec.rb
@@ -46,11 +46,11 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^4(.*)/
         after { MoneyRails.raise_error_on_money_parsing = false }
 
         it "raises exception if the mongoized value is a String with a hyphen" do
-          expect { priceable_from_string_with_hyphen }.to raise_error ArgumentError
+          expect { priceable_from_string_with_hyphen }.to raise_error Monetize::ParseError
         end
 
         it "raises exception if the mongoized value is a String with an unknown currency" do
-          expect { priceable_from_string_with_unknown_currency }.to raise_error ArgumentError
+          expect { priceable_from_string_with_unknown_currency }.to raise_error Monetize::ParseError
         end
       end
 

--- a/spec/mongoid/three_spec.rb
+++ b/spec/mongoid/three_spec.rb
@@ -46,11 +46,11 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
         after { MoneyRails.raise_error_on_money_parsing = false }
 
         it "raises exception if the mongoized value is a String with a hyphen" do
-          expect { priceable_from_string_with_hyphen }.to raise_error ArgumentError
+          expect { priceable_from_string_with_hyphen }.to raise_error Monetize::ParseError
         end
 
         it "raises exception if the mongoized value is a String with an unknown currency" do
-          expect { priceable_from_string_with_unknown_currency }.to raise_error ArgumentError
+          expect { priceable_from_string_with_unknown_currency }.to raise_error Monetize::ParseError
         end
       end
 

--- a/spec/mongoid/two_spec.rb
+++ b/spec/mongoid/two_spec.rb
@@ -50,7 +50,7 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^2(.*)/
         after { MoneyRails.raise_error_on_money_parsing = false }
 
         it "raises exception if the mongoized value is a String with a hyphen" do
-          expect { priceable_from_string_with_hyphen }.to raise_error ArgumentError
+          expect { priceable_from_string_with_hyphen }.to raise_error Monetize::ParseError
         end
       end
 


### PR DESCRIPTION
- Ruby 2.4 support
- Upgrade Money dependency from 6.7 to 6.8.1
- Upgrade Monetize dependency from 1.4.0 to 1.6.0

==

The rescue of `ArgumentError` is removed in favor of `Monetize::ParseError`.

ArgumentError is only raised if value is not an instance of Numeric.
https://github.com/RubyMoney/monetize/blob/master/lib/monetize.rb#L117

But this is only called if value is a Numeric.
https://github.com/RubyMoney/monetize/blob/master/lib/monetize.rb#L62