### PR TITLE
Add humanized_money_with_iso helper

### DIFF
--- a/lib/money-rails/helpers/action_view_extension.rb
+++ b/lib/money-rails/helpers/action_view_extension.rb
@@ -30,6 +30,10 @@ module MoneyRails
       humanized_money(value, options.merge(:symbol => true))
     end
 
+    def humanized_money_with_iso(value, options={})
+      humanized_money(value, options.merge(:symbol => value.currency.iso_code + ' '))
+    end
+
     def money_without_cents(value, options={})
       if !options || !options.is_a?(Hash)
         warn "money_without_cents now takes a hash of formatting options, please specify { :symbol => true }"

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -50,6 +50,14 @@ describe 'MoneyRails::ActionViewExtension', :type => :helper do
     it { is_expected.to include Money.default_currency.symbol }
   end
 
+  describe '#humanized_money_with_iso' do
+    subject { helper.humanized_money_with_iso Money.new(12500) }
+    it { is_expected.to be_a String }
+    it { is_expected.not_to include Money.default_currency.decimal_mark }
+    it { is_expected.to include Money.default_currency.iso_code }
+    it { is_expected.not_to include Money.default_currency.symbol }
+  end
+
   describe '#money_without_cents' do
     let(:options) { {} }
     subject { helper.money_without_cents Money.new(12500), options }
@@ -98,6 +106,15 @@ describe 'MoneyRails::ActionViewExtension', :type => :helper do
         it { is_expected.to include Money.default_currency.symbol }
         it { is_expected.to include "00" }
       end
+
+      describe '#humanized_money_with_iso' do
+        subject { helper.humanized_money_with_iso Money.new(12500) }
+        it { is_expected.to be_a String }
+        it { is_expected.not_to include Money.default_currency.decimal_mark }
+        it { is_expected.to include Money.default_currency.iso_code }
+        it { is_expected.not_to include Money.default_currency.symbol }
+        it { is_expected.to include "00" }
+      end
     end
 
     context 'with no_cents_if_whole: nil' do
@@ -121,6 +138,15 @@ describe 'MoneyRails::ActionViewExtension', :type => :helper do
         it { is_expected.to be_a String }
         it { is_expected.not_to include Money.default_currency.decimal_mark }
         it { is_expected.to include Money.default_currency.symbol }
+        it { is_expected.not_to include "00" }
+      end
+
+      describe '#humanized_money_with_iso' do
+        subject { helper.humanized_money_with_iso Money.new(12500) }
+        it { is_expected.to be_a String }
+        it { is_expected.not_to include Money.default_currency.decimal_mark }
+        it { is_expected.to include Money.default_currency.iso_code }
+        it { is_expected.not_to include Money.default_currency.symbol }
         it { is_expected.not_to include "00" }
       end
     end
@@ -148,6 +174,16 @@ describe 'MoneyRails::ActionViewExtension', :type => :helper do
         it { is_expected.to include Money.default_currency.symbol }
         it { is_expected.not_to include "00" }
       end
+
+      describe '#humanized_money_with_iso' do
+        subject { helper.humanized_money_with_iso Money.new(12500) }
+        it { is_expected.to be_a String }
+        it { is_expected.not_to include Money.default_currency.decimal_mark }
+        it { is_expected.to include Money.default_currency.iso_code }
+        it { is_expected.not_to include Money.default_currency.symbol }
+        it { is_expected.not_to include "00" }
+      end
+
     end
 
 


### PR DESCRIPTION
Closes #467.

Note that `Money` has no methods or settings to place the ISO code as a prefix/suffix depending on the locale: https://github.com/RubyMoney/money/issues/600. The suggested workaround in the README is as follows:

```ruby
m = Money.new('123', :gbp) # => #<Money fractional:123 currency:GBP>
m.format( symbol: m.currency.to_s + ' ') # => "GBP 1.23"
```

If supporting suffixes is something that you would like, let me know and we can figure out a good way to support it that's easy to integrate with locales as well. Otherwise let me know and I can update the README/docs before merging.

Thanks!