### PR TITLE
money-rails without rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ $ rails g money_rails:initializer
 There, you can define the default currency value and set other
 configuration parameters for the rails app.
 
+Without Rails in rack-based applications, call during initialization:
+
+```ruby
+MoneyRails::Hooks.init
+```
+
 ## Usage
 
 ### ActiveRecord

--- a/lib/money-rails.rb
+++ b/lib/money-rails.rb
@@ -10,7 +10,7 @@ module MoneyRails
   extend Configuration
 end
 
-if defined? Rails
+if defined? ::Rails::Railtie
   require "money-rails/railtie"
   require "money-rails/engine"
 end

--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -8,12 +8,12 @@ module MoneyRails
         require 'money-rails/active_model/validator'
         require 'money-rails/active_record/monetizable'
         ::ActiveRecord::Base.send :include, MoneyRails::ActiveRecord::Monetizable
-        if defined?(::Rails) && defined?(::Rails::VERSION)
-          if ::Rails::VERSION::MAJOR >= 4
+        if defined?(::ActiveRecord) && defined?(::ActiveRecord::VERSION)
+          if ::ActiveRecord::VERSION::MAJOR >= 4
             rails42               = case
-                                    when ::Rails::VERSION::MAJOR < 5 && ::Rails::VERSION::MINOR >= 2
+                                    when ::ActiveRecord::VERSION::MAJOR < 5 && ::ActiveRecord::VERSION::MINOR >= 2
                                       true
-                                    when ::Rails::VERSION::MAJOR >= 5
+                                    when ::ActiveRecord::VERSION::MAJOR >= 5
                                       true
                                     else
                                       false

--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -8,17 +8,19 @@ module MoneyRails
         require 'money-rails/active_model/validator'
         require 'money-rails/active_record/monetizable'
         ::ActiveRecord::Base.send :include, MoneyRails::ActiveRecord::Monetizable
-        if ::Rails::VERSION::MAJOR >= 4
-          rails42               = case
-                                  when ::Rails::VERSION::MAJOR < 5 && ::Rails::VERSION::MINOR >= 2
-                                    true
-                                  when ::Rails::VERSION::MAJOR >= 5
-                                    true
-                                  else
-                                    false
-                                  end
-          current_adapter = ::ActiveRecord::Base.connection_config[:adapter]
-          postgresql_with_money = rails42 && PG_ADAPTERS.include?(current_adapter)
+        if defined?(::Rails) && defined?(::Rails::VERSION)
+          if ::Rails::VERSION::MAJOR >= 4
+            rails42               = case
+                                    when ::Rails::VERSION::MAJOR < 5 && ::Rails::VERSION::MINOR >= 2
+                                      true
+                                    when ::Rails::VERSION::MAJOR >= 5
+                                      true
+                                    else
+                                      false
+                                    end
+            current_adapter = ::ActiveRecord::Base.connection_config[:adapter]
+            postgresql_with_money = rails42 && PG_ADAPTERS.include?(current_adapter)
+          end
         end
 
         require "money-rails/active_record/migration_extensions/options_extractor"


### PR DESCRIPTION
Hello and thanks for gem.
`require "money-rails/railtie"` and `require "money-rails/engine"` will fail because I don't have Rails and ::Rails::Railtie, ::Rails::Engine are not defined, but I'm using money-rails pretty long just with ActiveRecord by running `MoneyRails::Hooks.init`