### PR TITLE
Mention Rails 3/4 difference w.r.t. migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ helper can be customized inside a ```MoneyRails.configure``` block. You should c
 ```ruby
 class MonetizeProduct < ActiveRecord::Migration
   def change
-    add_money :products, :price
+    add_money :products, :price    # Rails 3
+    add_monetize :products, :price # Rails 4x and above
 
     # OR
 


### PR DESCRIPTION
The README mentions the difference between Rails 3 and 4 with regards to `change_table`, but not regarding the single-line `add_money` helper.

This PR rectifies this.