### PR TITLE
Add use_bank method to use it when you need to load money objects from active_record with custom bank conversion factors

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,30 @@ t = Transaction.new(:amount_cents => 2500, :currency => "CAD")
 t.amount == Money.new(2500, "CAD") # true
 ```
 
+####  Assigning Currencies on the go
+
+If you would like to assign different Currency stores(banks) on the go you can use the following method:
+
+`Money.with_bank(bank_of_america)`
+
+This is to allow the usage of custom currency stores to be loaded per User sessions.
+
+An example would be to use the following in a certain controller
+
+```ruby
+class ApplicationController
+  around_action :currency_store
+
+  def currency_store
+    Money.with_bank(Money::Bank::VariableExchange.new(MyCustomStore.new)) do
+      # Rate will be loaded from the current_user setup.
+      Money.add_rate("USD", "EUR", 0.5)
+      yield
+    end
+  end
+end
+```
+
 ### Configuration parameters
 
 You can handle a bunch of configuration params through ```money.rb``` initializer:

--- a/lib/money-rails/money.rb
+++ b/lib/money-rails/money.rb
@@ -4,6 +4,13 @@ require "active_support/core_ext/hash/reverse_merge.rb"
 class Money
   alias_method :orig_format, :format
 
+  def self.use_bank(bank)
+    old_bank, ::Money.default_bank = ::Money.default_bank, bank
+    yield
+  ensure
+    ::Money.default_bank = old_bank
+  end
+
   def format(*rules)
     rules = normalize_formatting_rules(rules)
 

--- a/lib/money-rails/money.rb
+++ b/lib/money-rails/money.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/hash/reverse_merge.rb"
 class Money
   alias_method :orig_format, :format
 
-  def self.use_bank(bank)
+  def self.with_bank(bank)
     old_bank, ::Money.default_bank = ::Money.default_bank, bank
     yield
   ensure
@@ -26,8 +26,6 @@ class Money
     unless MoneyRails::Configuration.default_format.nil?
       rules.reverse_merge!(MoneyRails::Configuration.default_format)
     end
-
     orig_format(rules)
   end
-
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -140,6 +140,15 @@ describe "configuration" do
         end
       end
     end
+  end
 
+  describe 'modifying default bank from memory' do
+    it 'creates new banks when needed' do
+      old_bank = Money.default_bank
+      bank = Money::RatesStore::Memory.new
+
+      Money.with_bank(bank) {}
+      expect(Money.default_bank).to eq(old_bank)
+    end
   end
 end


### PR DESCRIPTION
This is to allow the usage of custom currency stores to be loaded per User sessions.

An example would be to use the following in a certain controller

```ruby
  around_action :currency_store

  def currency_store
    Money.use_bank(Money::Bank::VariableExchange.new(MyCustomStore.new)) do
      # Rate will be loaded from the current_user setup.
      Money.add_rate("USD", "EUR", 0.5)
      yield    
    end
  end
``` 