### PR TITLE
amount column postfix always '_cents'

### DIFF
--- a/lib/money-rails/configuration.rb
+++ b/lib/money-rails/configuration.rb
@@ -37,7 +37,7 @@ module MoneyRails
     end
 
     def set_amount_column_for_default_currency!
-      amount_column.merge! postfix: "_#{default_currency.subunit.downcase.pluralize}" if default_currency.subunit
+      amount_column.merge! postfix: "_cents" if default_currency.subunit
     end
 
     def set_currency_column_for_default_currency!

--- a/lib/money-rails/configuration.rb
+++ b/lib/money-rails/configuration.rb
@@ -27,17 +27,12 @@ module MoneyRails
     # Set default currency of money library
     def default_currency=(currency_name)
       Money.default_currency = currency_name
-      set_amount_column_for_default_currency!
       set_currency_column_for_default_currency!
     end
 
     # Register a custom currency
     def register_currency=(currency_options)
       Money::Currency.register(currency_options)
-    end
-
-    def set_amount_column_for_default_currency!
-      amount_column.merge! postfix: "_cents" if default_currency.subunit
     end
 
     def set_currency_column_for_default_currency!

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -93,7 +93,9 @@ describe "configuration" do
       old_currency = MoneyRails.default_currency
       MoneyRails.default_currency = :inr
 
-      expect(MoneyRails.amount_column[:postfix]).to eq("_#{MoneyRails.default_currency.subunit.downcase.pluralize}")
+      expect(MoneyRails.default_currency.subunit).to eq 'Paisa'
+      expect(MoneyRails.amount_column[:postfix]).to eq("_cents") # not localized
+
       expect(MoneyRails.currency_column[:default]).to eq(MoneyRails.default_currency.iso_code)
 
       # Reset global setting


### PR DESCRIPTION
Until now subunit name of the default currency has been used as postfix of the amount column. This leads to various inconvenient situations, as discussed in https://github.com/RubyMoney/money-rails/issues/399