### PR TITLE
WIP: Custom predicate handler for ActiveRecord

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -1,3 +1,4 @@
+require 'money-rails/active_record/predicate_builder/money_handler'
 require 'active_support/concern'
 require 'active_support/core_ext/array/extract_options'
 require 'active_support/deprecation/reporting'
@@ -21,6 +22,12 @@ module MoneyRails
 
         def monetize(*fields)
           options = fields.extract_options!
+
+          if respond_to?(:predicate_builder)
+            self.predicate_builder.register_handler(Money, PredicateBuilder::MoneyHandler.new(self))
+          else
+            ::ActiveRecord::PredicateBuilder.register_handler(Money, PredicateBuilder::MoneyHandler.new)
+          end
 
           fields.each do |field|
             # Stringify model field name

--- a/lib/money-rails/active_record/predicate_builder/money_handler.rb
+++ b/lib/money-rails/active_record/predicate_builder/money_handler.rb
@@ -1,0 +1,23 @@
+module MoneyRails
+  module ActiveRecord
+    module PredicateBuilder
+      class MoneyHandler
+        def initialize(base_klass = nil)
+          @base_klass = base_klass
+        end
+
+        def call(attribute, value)
+          klass = base_klass || attribute.relation.engine
+
+          subunit_name = klass.monetized_attributes[attribute.name]
+
+          klass.arel_table[subunit_name].eq(value.cents)
+        end
+
+        private
+
+        attr_reader :base_klass
+      end
+    end
+  end
+end

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -1006,5 +1006,17 @@ if defined? ActiveRecord
         expect(currency).to eq(Money.default_currency)
       end
     end
+
+    describe "custom predicate" do
+      it "constructs a predicate for inferred monetized attribute" do
+        expect(Product.where(price: Money.new(99_00)).to_sql)
+          .to eq('SELECT "products".* FROM "products" WHERE "products"."price_cents" = 9900')
+      end
+
+      it "constructs a predicate for explicitly named monetized attribute" do
+        expect(Product.where(sale_price: Money.new(99_00)).to_sql)
+          .to eq('SELECT "products".* FROM "products" WHERE "products"."sale_price_amount" = 9900')
+      end
+    end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
Inspired by #488 

This is not yet mergeable, since the currency part of the value is not handled. While trying to implement that I realised that we might need to store the configuration somewhere rather than wrapping everything in the local scope, allowing us to reference it from other parts. This will also allow to easily finally split `Monetizable` module apart.