### PR TITLE
Create memoized amount using Money.new

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -193,7 +193,7 @@ module MoneyRails
           if memoized.currency == attr_currency
             result = memoized
           else
-            memoized_amount = memoized.amount.to_money(attr_currency)
+            memoized_amount = Money.new(amount, attr_currency)
             write_attribute subunit_name, memoized_amount.cents
             # Cache the value (it may be nil)
             result = instance_variable_set("@#{name}", memoized_amount)

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -810,14 +810,13 @@ if defined? ActiveRecord
           reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
           product.reduced_price_cents = 100
 
-          expect(product.read_monetized(:reduced_price, :reduced_price_cents)).not_to eq(reduced_price)
+          expect(product.read_monetized(:reduced_price, :reduced_price_cents)).to eq(Money.new(100, reduced_price.currency))
         end
 
         it "resets memoized attribute's value if currency has changed" do
           reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
-          product.reduced_price_currency = 'CAD'
-
-          expect(product.read_monetized(:reduced_price, :reduced_price_cents)).not_to eq(reduced_price)
+          product.reduced_price_currency = 'JPY'
+          expect(product.read_monetized(:reduced_price, :reduced_price_cents)).to eq(Money.new(reduced_price.cents, 'JPY'))
         end
       end
 


### PR DESCRIPTION
We had an issue upgrading money-rails where a record with a money value would get a cents value that was 100 times larger than it should be because it was first memoized as JPY, then converted to USD using `to_money` (which interprets the amount as dollars instead of cents).

This fixed the issue so I'm just posting to get feedback. I'm not very familiar with the internals of money-rails and why you would use `to_money` instead of `Money.new` here, but there is a drastic difference when you're dealing with currencies with and without subunits.