### PR TITLE
Add option to universally treat amounts as cents

### DIFF
--- a/lib/money-rails/configuration.rb
+++ b/lib/money-rails/configuration.rb
@@ -88,6 +88,9 @@ module MoneyRails
     mattr_accessor :default_format
     @@default_format = nil
 
+    mattr_accessor :treat_amounts_as_cents
+    @@treat_amounts_as_cents = false
+
     # Configure whether to raise exception when an improper value
     # is going to be converted to a Money object.
     mattr_accessor :raise_error_on_money_parsing

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -842,6 +842,21 @@ if defined? ActiveRecord
           expect(product.read_monetized(:price, :price_cents).to_s).to eq('14,0')
         end
       end
+
+      context "treating amounts as cents" do
+        around(:each) do |example|
+          MoneyRails::Configuration.treat_amounts_as_cents = true
+          example.run
+          MoneyRails::Configuration.treat_amounts_as_cents = false
+        end
+
+        it "resets memoized attribute's value if currency has changed" do
+          reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
+          product.reduced_price_currency = 'CAD'
+
+          expect(product.read_monetized(:reduced_price, :reduced_price_cents).cents).to eq(reduced_price.cents)
+        end
+      end
     end
 
     describe "#write_monetized" do
@@ -963,6 +978,21 @@ if defined? ActiveRecord
             # Can not use public accessor here because currency_for_price is stubbed
             expect(product.instance_variable_get('@price')).to eq(old_price_value)
           end
+        end
+      end
+
+      context "treating amounts as cents" do
+        around(:each) do |example|
+          MoneyRails::Configuration.treat_amounts_as_cents = true
+          example.run
+          MoneyRails::Configuration.treat_amounts_as_cents = false
+        end
+
+        it "sets monetized attribute's value directly from Fixnum amount as cents" do
+          product.write_monetized :price, :price_cents, 10, false, nil, {}
+
+          expect(product.price).to be_an_instance_of(Money)
+          expect(product.price_cents).to eq(10)
         end
       end
     end

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -819,6 +819,16 @@ if defined? ActiveRecord
 
           expect(product.read_monetized(:reduced_price, :reduced_price_cents)).not_to eq(reduced_price)
         end
+
+        it "resets memoized attribute's cents value based on updated currency if currency has changed" do
+          reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
+
+          product.reduced_price_currency = 'CAD'
+          expect(product.read_monetized(:reduced_price, :reduced_price_cents).cents).to eq(reduced_price.cents)
+
+          product.reduced_price_currency = 'JPY'
+          expect(product.read_monetized(:reduced_price, :reduced_price_cents).cents).to eq(reduced_price.cents / 100)
+        end
       end
 
       context "with preserve_user_input set" do
@@ -854,6 +864,16 @@ if defined? ActiveRecord
           reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
           product.reduced_price_currency = 'CAD'
 
+          expect(product.read_monetized(:reduced_price, :reduced_price_cents)).not_to eq(reduced_price)
+        end
+
+        it "resets memoized attribute's value as cents value if currency has changed" do
+          reduced_price = product.read_monetized(:reduced_price, :reduced_price_cents)
+
+          product.reduced_price_currency = 'CAD'
+          expect(product.read_monetized(:reduced_price, :reduced_price_cents).cents).to eq(reduced_price.cents)
+
+          product.reduced_price_currency = 'JPY'
           expect(product.read_monetized(:reduced_price, :reduced_price_cents).cents).to eq(reduced_price.cents)
         end
       end


### PR DESCRIPTION
This is an idea for deatling with #491.

I added an option, `treat_amounts_as_cents`, which is `false` by default but if set results in all amounts being treated as cents, so if the option is *off*:

```ruby
Payment.new(amount: 100, currency: "USD").cents
#=> 10000
```

whereas if it's *on*:

```ruby
Payment.new(amount: 100, currency: "USD").cents
#=> 100
```

This in fact was how things worked prior to v1.6.2 if you had a default currency that was cents-based (e.g. JPY). But in #421 it was pointed out that this had some strange results, such as converting 100 as an amount for a cents-based currency into 10000 if the subunit-to-unit ratio of the default currency is 100.

Obviously making conversion different depending on the default currency is a bad idea. As of v1.6.2, the interpretation of the amount depends on the currency, which is more consistent.

However, in many cases it is better to just treat *all* amounts as cents. This is in fact what RubyMoney itself does:

```ruby
Money.new(100, "USD").cents
#=> 100
```

I'm not sure if what I've done here is the best way to do this, so for now it's more of a proof of concept to discuss, and to see if specs pass on Travis.