### PR TITLE
Add a missing example for a case currency changing use case

### DIFF
--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -78,11 +78,23 @@ if defined? ActiveRecord
       end
 
       it "assigns the correct value from params" do
-        params_clp = { amount: '20000', tax: '1000', currency:  'CLP' }
+        params_clp = { amount: '20000', tax: '1000', currency: 'CLP' }
         product = Transaction.create(params_clp)
         expect(product.valid?).to be_truthy
         expect(product.amount.currency.subunit_to_unit).to eq(1)
         expect(product.amount_cents).to eq(20000)
+      end
+
+      # TODO: This is a slightly controversial example, btu it reflects the current behaviour
+      it "re-assigns cents amount when subunit/unit ratio changes preserving amount in units" do
+        transaction = Transaction.create(amount: '20000', tax: '1000', currency: 'USD')
+
+        expect(transaction.amount).to eq(Money.new(20000_00, 'USD'))
+
+        transaction.currency = 'CLP'
+
+        expect(transaction.amount).to eq(Money.new(20000, 'CLP'))
+        expect(transaction.amount_cents).to eq(20000)
       end
 
       it "raises an error if trying to create two attributes with the same name" do


### PR DESCRIPTION
This illustrates that the amount is preserved in units when currency is
changed to a different subunit/unit ratio. The example is controversial
and confusing, this commit just ensures that is covered by specs.

It covers a use-case described in #491. And this behaviour was introduces in #421.