### PR TITLE
Fix flakiness in Mongoid 3 & 4 specs

### DIFF
--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails",       ">= 3.0"
   s.add_development_dependency "rspec-rails", "~> 3.0"
-  s.add_development_dependency 'database_cleaner', ['>= 0.8.0', '< 1.4.0']
+  s.add_development_dependency 'database_cleaner', '~> 1.6.1'
   s.add_development_dependency 'test-unit', '~> 3.0' if RUBY_VERSION >= '2.2'
 end

--- a/spec/mongoid/four_spec.rb
+++ b/spec/mongoid/four_spec.rb
@@ -4,11 +4,11 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^4(.*)/
 
   describe Money do
     let!(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
-    let!(:priceable_from_nil) { Priceable.create(:price => nil) }
-    let!(:priceable_from_num) { Priceable.create(:price => 1) }
-    let!(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
-    let!(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
-    let!(:priceable_from_hash_with_indifferent_access) {
+    let(:priceable_from_nil) { Priceable.create(:price => nil) }
+    let(:priceable_from_num) { Priceable.create(:price => 1) }
+    let(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
+    let(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
+    let(:priceable_from_hash_with_indifferent_access) {
       Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"}.with_indifferent_access)
     }
     let(:priceable_from_string_with_hyphen) { Priceable.create(:price => '1-2 EUR' )}
@@ -99,6 +99,7 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^4(.*)/
 
     context "demongoize" do
       subject { Priceable.first.price }
+
       it { is_expected.to be_an_instance_of(Money) }
       it { is_expected.to eq(Money.new(100, 'EUR')) }
 

--- a/spec/mongoid/three_spec.rb
+++ b/spec/mongoid/three_spec.rb
@@ -4,11 +4,11 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
 
   describe Money do
     let!(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
-    let!(:priceable_from_nil) { Priceable.create(:price => nil) }
-    let!(:priceable_from_num) { Priceable.create(:price => 1) }
-    let!(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
-    let!(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
-    let!(:priceable_from_hash_with_indifferent_access) {
+    let(:priceable_from_nil) { Priceable.create(:price => nil) }
+    let(:priceable_from_num) { Priceable.create(:price => 1) }
+    let(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
+    let(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
+    let(:priceable_from_hash_with_indifferent_access) {
       Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"}.with_indifferent_access)
     }
     let(:priceable_from_string_with_hyphen) { Priceable.create(:price => '1-2 EUR' )}


### PR DESCRIPTION
Since there are 6 pre-created Priceable records for every test and there
is no sorting, we can not rely on the order in which they are returned.
This fix will only force the creation of one DB record.