### PR TITLE
Return early from reading monetized attribute if nil amount and allow_nil is set

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -119,7 +119,7 @@ module MoneyRails
 
             # Getter for monetized attribute
             define_method name do |*args|
-              read_monetized name, subunit_name, *args
+              read_monetized name, subunit_name, options, *args
             end
 
             # Setter for monetized attribute
@@ -178,10 +178,11 @@ module MoneyRails
         end
       end
 
-      def read_monetized(name, subunit_name, *args)
+      def read_monetized(name, subunit_name, options = {}, *args)
         # Get the cents
         amount = public_send(subunit_name, *args)
 
+        return if amount.nil? && options[:allow_nil]
         # Get the currency object
         attr_currency = public_send("currency_for_#{name}")
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -870,18 +870,9 @@ if defined? ActiveRecord
           Money.default_currency = original_default_currency
         end
 
-        context "when allow_nil options is not set" do
-          let(:options) { {} }
-
-          it "attempts to read the fallback default currency" do
-            expect(default_currency_lambda).to receive(:read_currency).and_return("USD")
-            subject
-          end
-        end
-
         context "when allow_nil options is set" do
           let(:options) { { allow_nil: true } }
-          it "attempts to read the fallback default currency" do
+          it "does not attempt to read the fallback default currency" do
             expect(default_currency_lambda).not_to receive(:read_currency)
             subject
           end

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -854,6 +854,39 @@ if defined? ActiveRecord
           expect(product.read_monetized(:price, :price_cents).to_s).to eq('14,0')
         end
       end
+
+      context "with a monetized attribute that is nil" do
+        let(:service) do
+          Service.create(discount_cents: nil)
+        end
+        let(:default_currency_lambda) { double("Default Currency Fallback") }
+        subject { service.read_monetized(:discount, :discount_cents, options) }
+
+        around(:each) do |example|
+          service # Instantiate instance which relies on Money.default_currency
+          original_default_currency = Money.default_currency
+          Money.default_currency = -> { default_currency_lambda.read_currency }
+          example.run
+          Money.default_currency = original_default_currency
+        end
+
+        context "when allow_nil options is not set" do
+          let(:options) { {} }
+
+          it "attempts to read the fallback default currency" do
+            expect(default_currency_lambda).to receive(:read_currency).and_return("USD")
+            subject
+          end
+        end
+
+        context "when allow_nil options is set" do
+          let(:options) { { allow_nil: true } }
+          it "attempts to read the fallback default currency" do
+            expect(default_currency_lambda).not_to receive(:read_currency)
+            subject
+          end
+        end
+      end
     end
 
     describe "#write_monetized" do


### PR DESCRIPTION
## Issue:
For a monetized attribute that is nil and is allowed to be nil, a corresponding currency is always attempted to be read. This causes issues because the `currency_for` method might call the `Money.default_currency` which for some multi-tenant applications could throw an error if called outside of a specific context.

## Solution:
If the monetized attribute is nil and is allowed to be nil, immediately return nil without attempting to read the corresponding currency. 
