### PR TITLE
Add test helper for with_model_currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,13 @@ is_expected.to monetize(:price).with_currency(:gbp)
 By using the `with_currency` chain you can specify the expected currency
 for the chosen money attribute. (You can also combine all the chains.)
 
+```ruby
+is_expected.to monetize(:price).with_model_currency(:currency)
+```
+
+By using the `with_model_currency` chain you can specify the attribute that
+contains the currency to be used for the chosen money attribute.
+
 For examples on using the test_helpers look at
 [test_helpers_spec.rb](https://github.com/RubyMoney/money-rails/blob/master/spec/test_helpers_spec.rb)
 

--- a/lib/money-rails/test_helpers.rb
+++ b/lib/money-rails/test_helpers.rb
@@ -81,21 +81,21 @@ module MoneyRails
 
       def test_allow_nil
         if @allow_nil
-          @actual.send(@money_attribute_setter, "")
-          @actual.send(@money_attribute).nil?
+          @actual.public_send(@money_attribute_setter, "")
+          @actual.public_send(@money_attribute).nil?
         else
           true
         end
       end
 
       def is_monetized?
-        @actual.send(@money_attribute_setter, 1)
-        @actual.send(@money_attribute).instance_of?(Money)
+        @actual.public_send(@money_attribute_setter, 1)
+        @actual.public_send(@money_attribute).instance_of?(Money)
       end
 
       def test_currency_iso
         if @currency_iso
-          @actual.send(@money_attribute).currency.id == @currency_iso
+          @actual.public_send(@money_attribute).currency.id == @currency_iso
         else
           true
         end
@@ -103,7 +103,7 @@ module MoneyRails
 
       def test_currency_attribute
         if @currency_attribute
-          @actual.send(@money_attribute).currency == @actual.send(@currency_attribute)
+          @actual.public_send(@money_attribute).currency == @actual.public_send(@currency_attribute)
         else
           true
         end

--- a/lib/money-rails/test_helpers.rb
+++ b/lib/money-rails/test_helpers.rb
@@ -16,6 +16,11 @@ module MoneyRails
         self
       end
 
+      def with_model_currency(attribute)
+        @currency_attribute = attribute
+        self
+      end
+
       def as(virt_attr)
         @as = virt_attr
         self
@@ -39,7 +44,8 @@ module MoneyRails
         object_responds_to_attributes? &&
           test_allow_nil &&
           is_monetized? &&
-          test_currency_iso
+          test_currency_iso &&
+          test_currency_attribute
       end
 
 
@@ -90,6 +96,14 @@ module MoneyRails
       def test_currency_iso
         if @currency_iso
           @actual.send(@money_attribute).currency.id == @currency_iso
+        else
+          true
+        end
+      end
+
+      def test_currency_attribute
+        if @currency_attribute
+          @actual.send(@money_attribute).currency == @actual.send(@currency_attribute)
         else
           true
         end

--- a/spec/test_helpers_spec.rb
+++ b/spec/test_helpers_spec.rb
@@ -37,6 +37,14 @@ if defined? ActiveRecord
           is_expected.to monetize(:bonus).with_currency(:gbp)
         end
 
+        it "matches model attribute with currency attribute specified by :with_model_currency chain" do
+          is_expected.to(
+            monetize(:sale_price_amount)
+              .as(:sale_price)
+              .with_model_currency(:sale_price_currency_code)
+          )
+        end
+
         it "does not match non existed attribute" do
           is_expected.not_to monetize(:price_fake)
         end


### PR DESCRIPTION
So that in your Rails model specs you can do something like:

````
it { is_expected.to monetize(:sale_price_amount)
  .as(:sale_price)
  .with_model_currency(:sale_price_currency_code) }
````