### PR TITLE
Removed appearance of empty values in errors

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -33,7 +33,7 @@ module MoneyRails
         normalize_raw_value!
         super(@record, @attr, @raw_value)
 
-        if stringy and not @record.errors.added?(@attr, :not_a_number)
+        if stringy and record_does_not_have_error?
           add_error if
             value_has_too_many_decimal_points or
             thousand_separator_after_decimal_mark or
@@ -42,6 +42,11 @@ module MoneyRails
       end
 
       private
+
+      def record_does_not_have_error?
+        return true unless @record.errors.has_key?(@attr)
+        !@record.errors.added?(@attr, :not_a_number)
+      end
 
       def reset_memoized_variables!
         [:currency, :decimal_mark, :thousands_separator, :symbol,

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -213,6 +213,12 @@ if defined? ActiveRecord
         expect(product.save).to be_truthy
       end
 
+      it "shouldn't init empty key in errors" do
+        product.price = Money.new(320, "USD")
+        product.valid?
+        expect(product.errors.has_key?(:price)).to be_falsey
+      end
+
       it "fails validation with the proper error message if money value is invalid decimal" do
         product.price = "12.23.24"
         expect(product.save).to be_falsey


### PR DESCRIPTION
I found the very minor, but annoying bug(or feature?).

I use gem's validations for price, it adds empty array to errors for that price. So if another field is invalid I have next errors: { name: ['is too short'], current_price: [] }