### PR TITLE
Switch the gem to ruby hash syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ money attribute, then you can provide an ```as``` argument with a string
 value to the ```monetize``` macro:
 
 ```ruby
-monetize :discount_subunit, :as => "discount"
+monetize :discount_subunit, as: "discount"
 ```
 
 Now the model objects will have a ```discount``` attribute which is a `Money`
@@ -135,7 +135,7 @@ monetized field, you can use the `:allow_nil` parameter:
 
 ```ruby
 # in Product model
-monetize :optional_price_cents, :allow_nil => true
+monetize :optional_price_cents, allow_nil: true
 
 # in Migration
 def change
@@ -166,10 +166,10 @@ You can also pass along
 such as this:
 
 ```ruby
-monetize :price_in_a_range_cents, :allow_nil => true,
-  :numericality => {
-    :greater_than_or_equal_to => 0,
-    :less_than_or_equal_to => 10000
+monetize :price_in_a_range_cents, allow_nil: true,
+  numericality: {
+    greater_than_or_equal_to: 0,
+    less_than_or_equal_to: 10000
   }
 ```
 
@@ -177,14 +177,14 @@ Or, if you prefer, you can skip validations entirely for the attribute. This is 
 are aggregate methods and you wish to avoid executing them on every record save.
 
 ```ruby
-monetize :price_in_a_range_cents, :disable_validation => true
+monetize :price_in_a_range_cents, disable_validation: true
 ```
 
 You can also skip validations independently from each other by simply passing `false`
 to the validation you are willing to skip, like this:
 
 ```ruby
-monetize :price_in_a_range_cents, :numericality => false
+monetize :price_in_a_range_cents, numericality: false
 ```
 
 ### Mongoid 2.x and 3.x
@@ -214,14 +214,14 @@ obj.save
 # => true
 
 obj
-# => #<Product _id: 4fe865699671383656000001, _type: nil, price: {:cents=>100, :currency_iso=>"EUR"}>
+# => #<Product _id: 4fe865699671383656000001, _type: nil, price: {cents: 100, currency_iso: "EUR"}>
 
 obj.price
 #=> #<Money cents:100 currency:EUR>
 
 ## You can access the money hash too:
 obj[:price]
-# => {:cents=>100, :currency_iso=>"EUR"}
+# => {cents: 100, currency_iso: "EUR"}
 ```
 
 The usual options on `field` as `index`, `default`, ..., are available.
@@ -292,7 +292,7 @@ class Product < ActiveRecord::Base
   # Use EUR as model level currency
   register_currency :eur
 
-  monetize :discount_subunit, :as => "discount"
+  monetize :discount_subunit, as: "discount"
   monetize :bonus_cents
 
 end
@@ -320,8 +320,8 @@ class Product < ActiveRecord::Base
   # Use EUR as the model level currency
   register_currency :eur
 
-  monetize :discount_subunit, :as => "discount"
-  monetize :bonus_cents, :with_currency => :gbp
+  monetize :discount_subunit, as: "discount"
+  monetize :bonus_cents, with_currency: :gbp
 
 end
 ```
@@ -357,7 +357,7 @@ end
 
 # Now instantiating with a specific currency overrides
 # the model and global currencies
-t = Transaction.new(:amount_cents => 2500, :currency => "CAD")
+t = Transaction.new(amount_cents: 2500, currency: "CAD")
 t.amount == Money.new(2500, "CAD") # true
 ```
 
@@ -413,15 +413,15 @@ MoneyRails.configure do |config|
   #
   # Example:
   # config.register_currency = {
-  #   :priority            => 1,
-  #   :iso_code            => "EU4",
-  #   :name                => "Euro with subunit of 4 digits",
-  #   :symbol              => "€",
-  #   :symbol_first        => true,
-  #   :subunit             => "Subcent",
-  #   :subunit_to_unit     => 10000,
-  #   :thousands_separator => ".",
-  #   :decimal_mark        => ","
+  #   priority:            1,
+  #   iso_code:            "EU4",
+  #   name:                "Euro with subunit of 4 digits",
+  #   symbol:              "€",
+  #   symbol_first:        true,
+  #   subunit:             "Subcent",
+  #   subunit_to_unit:     10000,
+  #   thousands_separator: ".",
+  #   decimal_mark:        ","
   # }
 
   # Specify a rounding mode
@@ -444,9 +444,9 @@ MoneyRails.configure do |config|
   # Example:
   #
   # config.default_format = {
-  #   :no_cents_if_whole => nil,
-  #   :symbol => nil,
-  #   :sign_before_symbol => nil
+  #   no_cents_if_whole: nil,
+  #   symbol: nil,
+  #   sign_before_symbol: nil
   # }
 end
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -21,9 +21,9 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new
 
-task :default => "spec:all"
-task :test => :spec
-task :spec => :prepare_test_env
+task default: "spec:all"
+task test: :spec
+task spec: :prepare_test_env
 
 desc "Prepare money-rails engine test environment"
 task :prepare_test_env do
@@ -79,13 +79,13 @@ namespace :spec do
   task(:rails3) { run_with_gemfile 'gemfiles/rails3.gemfile' }
 
   desc "Run Tests against mongoid 2 & 3 & 4, 5"
-  task :mongoid => [:mongoid2, :mongoid3, :mongoid4, :mongoid5]
+  task mongoid: [:mongoid2, :mongoid3, :mongoid4, :mongoid5]
 
   desc "Run Tests against rails 3 & 4 & 4.1 & 4.2 & 5.0"
-  task :rails => [:rails3, :rails4, :rails41, :rails42, :rails50, :rails51]
+  task rails: [:rails3, :rails4, :rails41, :rails42, :rails50, :rails51]
 
   desc "Run Tests against all ORMs"
-  task :all => [:rails, :mongoid]
+  task all: [:rails, :mongoid]
 
 end
 

--- a/gemfiles/mongoid2.gemfile
+++ b/gemfiles/mongoid2.gemfile
@@ -14,4 +14,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/gemfiles/mongoid3.gemfile
+++ b/gemfiles/mongoid3.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/gemfiles/mongoid4.gemfile
+++ b/gemfiles/mongoid4.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/gemfiles/mongoid5.gemfile
+++ b/gemfiles/mongoid5.gemfile
@@ -14,4 +14,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/gemfiles/rails3.gemfile
+++ b/gemfiles/rails3.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -12,4 +12,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -12,4 +12,4 @@ platforms :ruby do
   gem "sqlite3"
 end
 
-gemspec :path => '../'
+gemspec path: '../'

--- a/lib/generators/templates/money.rb
+++ b/lib/generators/templates/money.rb
@@ -47,15 +47,15 @@ MoneyRails.configure do |config|
   #
   # Example:
   # config.register_currency = {
-  #   :priority            => 1,
-  #   :iso_code            => "EU4",
-  #   :name                => "Euro with subunit of 4 digits",
-  #   :symbol              => "€",
-  #   :symbol_first        => true,
-  #   :subunit             => "Subcent",
-  #   :subunit_to_unit     => 10000,
-  #   :thousands_separator => ".",
-  #   :decimal_mark        => ","
+  #   priority:            1,
+  #   iso_code:            "EU4",
+  #   name:                "Euro with subunit of 4 digits",
+  #   symbol:              "€",
+  #   symbol_first:        true,
+  #   subunit:             "Subcent",
+  #   subunit_to_unit:     10000,
+  #   thousands_separator: ".",
+  #   decimal_mark:        ","
   # }
 
   # Specify a rounding mode
@@ -78,9 +78,9 @@ MoneyRails.configure do |config|
   # Example:
   #
   # config.default_format = {
-  #   :no_cents_if_whole => nil,
-  #   :symbol => nil,
-  #   :sign_before_symbol => nil
+  #   no_cents_if_whole: nil,
+  #   symbol: nil,
+  #   sign_before_symbol: nil
   # }
 
   # Set default raise_error_on_money_parsing option

--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -83,10 +83,10 @@ module MoneyRails
         attr_name = @record.class.human_attribute_name(@attr, default: attr_name)
 
         @record.errors.add(@attr, :invalid_currency,
-                           { :thousands => thousands_separator,
-                             :decimal => decimal_mark,
-                             :currency => abs_raw_value,
-                             :attribute => attr_name })
+                           { thousands: thousands_separator,
+                             decimal: decimal_mark,
+                             currency: abs_raw_value,
+                             attribute: attr_name })
       end
 
       def decimal_pieces

--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -84,33 +84,33 @@ module MoneyRails
             # All the options which are available for Rails numericality
             # validation, are also available for both types.
             # E.g.
-            #   monetize :price_in_a_range_cents, :allow_nil => true,
-            #     :subunit_numericality => {
-            #       :greater_than_or_equal_to => 0,
-            #       :less_than_or_equal_to => 10000,
+            #   monetize :price_in_a_range_cents, allow_nil: true,
+            #     subunit_numericality: {
+            #       greater_than_or_equal_to: 0,
+            #       less_than_or_equal_to: 10000,
             #     },
-            #     :numericality => {
-            #       :greater_than_or_equal_to => 0,
-            #       :less_than_or_equal_to => 100,
-            #       :message => "must be greater than zero and less than $100"
+            #     numericality: {
+            #       greater_than_or_equal_to: 0,
+            #       less_than_or_equal_to: 100,
+            #       message: "must be greater than zero and less than $100"
             #     }
             #
             # To disable validation entirely, use :disable_validation, E.g:
-            #   monetize :price_in_a_range_cents, :disable_validation => true
+            #   monetize :price_in_a_range_cents, disable_validation: true
             if (validation_enabled = MoneyRails.include_validations && !options[:disable_validation])
 
               # This is a validation for the subunit
               if (subunit_numericality = options.fetch(:subunit_numericality, true))
                 validates subunit_name, {
-                  :allow_nil => options[:allow_nil],
-                  :numericality => subunit_numericality
+                  allow_nil: options[:allow_nil],
+                  numericality: subunit_numericality
                 }
               end
 
               # Allow only Money objects or Numeric values!
               if (numericality = options.fetch(:numericality, true))
                 validates name.to_sym, {
-                  :allow_nil => options[:allow_nil],
+                  allow_nil: options[:allow_nil],
                   'money_rails/active_model/money' => numericality
                 }
               end

--- a/lib/money-rails/configuration.rb
+++ b/lib/money-rails/configuration.rb
@@ -59,10 +59,10 @@ module MoneyRails
     #   MoneyRails.configure do |config|
     #     config.default_bank = EuCentralBank.new
     #   end
-    delegate :default_bank=, :default_bank, :to => :Money
+    delegate :default_bank=, :default_bank, to: :Money
 
     # Provide exchange rates
-    delegate :add_rate, :to => :Money
+    delegate :add_rate, to: :Money
 
     # Use (by default) validation of numericality for each monetized field.
     mattr_accessor :include_validations

--- a/lib/money-rails/helpers/action_view_extension.rb
+++ b/lib/money-rails/helpers/action_view_extension.rb
@@ -2,18 +2,18 @@ module MoneyRails
   module ActionViewExtension
 
     def currency_symbol
-      content_tag(:span, Money.default_currency.symbol, :class => "currency_symbol")
+      content_tag(:span, Money.default_currency.symbol, class: "currency_symbol")
     end
 
     def humanized_money(value, options={})
       if !options || !options.is_a?(Hash)
-        warn "humanized_money now takes a hash of formatting options, please specify { :symbol => true }"
-        options = { :symbol => options }
+        warn "humanized_money now takes a hash of formatting options, please specify { symbol: true }"
+        options = { symbol: options }
       end
 
       options = {
-        :no_cents_if_whole => MoneyRails::Configuration.no_cents_if_whole.nil? ? true : MoneyRails::Configuration.no_cents_if_whole,
-        :symbol => false
+        no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole.nil? ? true : MoneyRails::Configuration.no_cents_if_whole,
+        symbol: false
       }.merge(options)
       options.delete(:symbol) if options[:disambiguate]
 
@@ -27,26 +27,26 @@ module MoneyRails
     end
 
     def humanized_money_with_symbol(value, options={})
-      humanized_money(value, options.merge(:symbol => true))
+      humanized_money(value, options.merge(symbol: true))
     end
 
     def money_without_cents(value, options={})
       if !options || !options.is_a?(Hash)
-        warn "money_without_cents now takes a hash of formatting options, please specify { :symbol => true }"
-        options = { :symbol => options }
+        warn "money_without_cents now takes a hash of formatting options, please specify { symbol: true }"
+        options = { symbol: options }
       end
 
       options = {
-        :no_cents => true,
-        :no_cents_if_whole => false,
-        :symbol => false
+        no_cents: true,
+        no_cents_if_whole: false,
+        symbol: false
       }.merge(options)
 
       humanized_money(value, options)
     end
 
     def money_without_cents_and_with_symbol(value)
-      money_without_cents(value, :symbol => true)
+      money_without_cents(value, symbol: true)
     end
   end
 end

--- a/lib/money-rails/mongoid/money.rb
+++ b/lib/money-rails/mongoid/money.rb
@@ -3,8 +3,8 @@ class Money
   # Converts an object of this instance into a database friendly value.
   def mongoize
     {
-      :cents        => cents.mongoize.to_f,
-      :currency_iso => currency.iso_code.mongoize
+      cents:        cents.mongoize.to_f,
+      currency_iso: currency.iso_code.mongoize
     }
   end
 

--- a/lib/money-rails/mongoid/two.rb
+++ b/lib/money-rails/mongoid/two.rb
@@ -18,8 +18,8 @@ class Money
     case
     when object.is_a?(Money)
       {
-        :cents        => object.cents.is_a?(BigDecimal) ? object.cents.to_s : object.cents,
-        :currency_iso => object.currency.iso_code
+        cents:        object.cents.is_a?(BigDecimal) ? object.cents.to_s : object.cents,
+        currency_iso: object.currency.iso_code
       }
     when object.nil? then nil
     when object.respond_to?(:to_money)

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -7,17 +7,17 @@ class Sub < Product; end
 if defined? ActiveRecord
   describe MoneyRails::ActiveRecord::Monetizable do
     let(:product) do
-      Product.create(:price_cents => 3000, :discount => 150,
-                     :bonus_cents => 200, :optional_price => 100,
-                     :sale_price_amount => 1200, :delivery_fee_cents => 100,
-                     :restock_fee_cents => 2000,
-                     :reduced_price_cents => 1500, :reduced_price_currency => :lvl,
-                     :lambda_price_cents => 4000)
+      Product.create(price_cents: 3000, discount: 150,
+                     bonus_cents: 200, optional_price: 100,
+                     sale_price_amount: 1200, delivery_fee_cents: 100,
+                     restock_fee_cents: 2000,
+                     reduced_price_cents: 1500, reduced_price_currency: :lvl,
+                     lambda_price_cents: 4000)
     end
 
     describe ".monetize" do
       let(:service) do
-        Service.create(:charge_cents => 2000, :discount_cents => 120)
+        Service.create(charge_cents: 2000, discount_cents: 120)
       end
 
       context ".monetized_attributes" do
@@ -66,14 +66,14 @@ if defined? ActiveRecord
       end
 
       it "assigns the correct value from a Money object using create" do
-        product = Product.create(:price => Money.new(3210, "USD"), :discount => 150,
-                                 :bonus_cents => 200, :optional_price => 100)
+        product = Product.create(price: Money.new(3210, "USD"), discount: 150,
+                                 bonus_cents: 200, optional_price: 100)
         expect(product.valid?).to be_truthy
         expect(product.price_cents).to eq(3210)
       end
 
       it "correctly updates from a Money object using update_attributes" do
-        expect(product.update_attributes(:price => Money.new(215, "USD"))).to be_truthy
+        expect(product.update_attributes(price: Money.new(215, "USD"))).to be_truthy
         expect(product.price_cents).to eq(215)
       end
 
@@ -187,8 +187,8 @@ if defined? ActiveRecord
       end
 
       it "respects numericality validation when using update_attributes" do
-        expect(product.update_attributes(:price_cents => "some text")).to be_falsey
-        expect(product.update_attributes(:price_cents => 2000)).to be_truthy
+        expect(product.update_attributes(price_cents: "some text")).to be_falsey
+        expect(product.update_attributes(price_cents: 2000)).to be_truthy
       end
 
       it "uses numericality validation on money attribute" do
@@ -309,9 +309,9 @@ if defined? ActiveRecord
       end
 
       it "fails validation if linked attribute changed" do
-        product = Product.create(:price => Money.new(3210, "USD"), :discount => 150,
-                                 :validates_method_amount => 100,
-                                 :bonus_cents => 200, :optional_price => 100)
+        product = Product.create(price: Money.new(3210, "USD"), discount: 150,
+                                 validates_method_amount: 100,
+                                 bonus_cents: 200, optional_price: 100)
         expect(product.valid?).to be_truthy
         product.optional_price = 50
         expect(product.valid?).to be_falsey
@@ -371,22 +371,22 @@ if defined? ActiveRecord
       end
 
       it "fails validation when a non number string is given" do
-        product = Product.create(:price_in_a_range => "asd")
+        product = Product.create(price_in_a_range: "asd")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range].size).to eq(1)
         expect(product.errors[:price_in_a_range].first).to match(/greater than zero/)
 
-        product = Product.create(:price_in_a_range => "asd23")
+        product = Product.create(price_in_a_range: "asd23")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range].size).to eq(1)
         expect(product.errors[:price_in_a_range].first).to match(/greater than zero/)
 
-        product = Product.create(:price => "asd")
+        product = Product.create(price: "asd")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price].size).to eq(1)
         expect(product.errors[:price].first).to match(/is not a number/)
 
-        product = Product.create(:price => "asd23")
+        product = Product.create(price: "asd23")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price].size).to eq(1)
         expect(product.errors[:price].first).to match(/is not a number/)
@@ -415,8 +415,8 @@ if defined? ActiveRecord
       end
 
       it "respects numericality validation when using update_attributes on money attribute" do
-        expect(product.update_attributes(:price => "some text")).to be_falsey
-        expect(product.update_attributes(:price => Money.new(320, 'USD'))).to be_truthy
+        expect(product.update_attributes(price: "some text")).to be_falsey
+        expect(product.update_attributes(price: Money.new(320, 'USD'))).to be_truthy
       end
 
       it "uses i18n currency format when validating" do
@@ -592,8 +592,8 @@ if defined? ActiveRecord
       end
 
       it "sets field to nil, in instantiation if allow_nil is set" do
-        pr = Product.new(:optional_price => nil, :price_cents => 5320,
-                         :discount => 350, :bonus_cents => 320)
+        pr = Product.new(optional_price: nil, price_cents: 5320,
+                         discount: 350, bonus_cents: 320)
         expect(pr.optional_price).to be_nil
         expect(pr.save).to be_truthy
         expect(pr.optional_price).to be_nil
@@ -615,23 +615,23 @@ if defined? ActiveRecord
 
       context "for column with model currency:" do
         it "has default currency if not specified" do
-          product = Product.create(:sale_price_amount => 1234)
+          product = Product.create(sale_price_amount: 1234)
           product.sale_price.currency_as_string == 'USD'
         end
 
         it "is overridden by instance currency column" do
-          product = Product.create(:sale_price_amount => 1234,
-                                   :sale_price_currency_code => 'CAD')
+          product = Product.create(sale_price_amount: 1234,
+                                   sale_price_currency_code: 'CAD')
           expect(product.sale_price.currency_as_string).to eq('CAD')
         end
 
         it 'can change currency of custom column' do
           product = Product.create!(
-            :price => Money.new(10,'USD'),
-            :bonus => Money.new(10,'GBP'),
-            :discount => 10,
-            :sale_price_amount => 1234,
-            :sale_price_currency_code => 'USD'
+            price: Money.new(10,'USD'),
+            bonus: Money.new(10,'GBP'),
+            discount: 10,
+            sale_price_amount: 1234,
+            sale_price_currency_code: 'USD'
           )
 
           expect(product.sale_price.currency_as_string).to eq('USD')
@@ -647,21 +647,21 @@ if defined? ActiveRecord
 
       context "for model with currency column:" do
         let(:transaction) do
-          Transaction.create(:amount_cents => 2400, :tax_cents => 600,
-                             :currency => :usd)
+          Transaction.create(amount_cents: 2400, tax_cents: 600,
+                             currency: :usd)
         end
 
         let(:dummy_product) do
-          DummyProduct.create(:price_cents => 2400, :currency => :usd)
+          DummyProduct.create(price_cents: 2400, currency: :usd)
         end
 
         let(:dummy_product_with_nil_currency) do
-          DummyProduct.create(:price_cents => 2600) # nil currency
+          DummyProduct.create(price_cents: 2600) # nil currency
         end
 
         let(:dummy_product_with_invalid_currency) do
           # invalid currency
-          DummyProduct.create(:price_cents => 2600, :currency => :foo)
+          DummyProduct.create(price_cents: 2600, currency: :foo)
         end
 
         it "correctly serializes the currency to a new instance of model" do
@@ -697,7 +697,7 @@ if defined? ActiveRecord
         end
 
         it "correctly instantiates Money objects from the mapped attributes" do
-          t = Transaction.new(:amount_cents => 2500, :currency => "CAD")
+          t = Transaction.new(amount_cents: 2500, currency: "CAD")
           expect(t.amount).to eq(Money.new(2500, "CAD"))
         end
 
@@ -732,7 +732,7 @@ if defined? ActiveRecord
 
         context "and field with allow_nil: true" do
           it "doesn't set currency to nil when setting the field to nil" do
-            t = Transaction.new(:amount_cents => 2500, :currency => "CAD")
+            t = Transaction.new(amount_cents: 2500, currency: "CAD")
             t.optional_amount = nil
             expect(t.currency).to eq("CAD")
           end
@@ -913,7 +913,7 @@ if defined? ActiveRecord
       end
 
       it "resets monetized attribute when given blank input" do
-        product.write_monetized :price, :price_cents, nil, false, nil, { :allow_nil => true }
+        product.write_monetized :price, :price_cents, nil, false, nil, { allow_nil: true }
 
         expect(product.price).to eq(nil)
       end
@@ -1011,7 +1011,7 @@ if defined? ActiveRecord
 
     describe "#currency_for" do
       it "detects currency based on instance currency name" do
-        product = Product.new(:sale_price_currency_code => 'CAD')
+        product = Product.new(sale_price_currency_code: 'CAD')
         currency = product.send(:currency_for, :sale_price, :sale_price_currency_code, nil)
 
         expect(currency).to be_an_instance_of(Money::Currency)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -76,11 +76,11 @@ describe "configuration" do
       value = Money.new(-12345600, "EUR")
       symbol = Money::Currency.find(:eur).symbol
 
-      MoneyRails.default_format = {:symbol_position => :after}
+      MoneyRails.default_format = {symbol_position: :after}
       expect(value.format).to match(/#{symbol}\z/)
 
       # Override with "classic" format options for backward compatibility
-      MoneyRails.default_format = {:sign_before_symbol => :false}
+      MoneyRails.default_format = {sign_before_symbol: :false}
       MoneyRails.sign_before_symbol = true
       expect(value.format).to match(/-#{symbol}/)
 

--- a/spec/dummy/app/models/dummy_product.rb
+++ b/spec/dummy/app/models/dummy_product.rb
@@ -3,6 +3,6 @@ class DummyProduct < ActiveRecord::Base
   register_currency :gbp
 
   # Use money-rails macros
-  monetize :price_cents, :with_model_currency => :currency
+  monetize :price_cents, with_model_currency: :currency
 end
 

--- a/spec/dummy/app/models/priceable.rb
+++ b/spec/dummy/app/models/priceable.rb
@@ -2,7 +2,7 @@ if defined? Mongoid
   class Priceable
     include Mongoid::Document
 
-    field :price, :type => Money
-    field :price_hash, :type => Hash
+    field :price, type: Money
+    field :price_hash, type: Hash
   end
 end

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -22,14 +22,15 @@ class Product < ActiveRecord::Base
     with_model_currency: :sale_price_currency_code
 
   monetize :price_in_a_range_cents, allow_nil: true,
-  subunit_numericality: {
-    greater_than: 0,
-  less_than_or_equal_to: 10000 },
-  numericality: {
-    greater_than: 0,
-    less_than_or_equal_to: 100,
-    message: "must be greater than zero and less than $100"
-  }
+                                    subunit_numericality: {
+                                      greater_than: 0,
+                                      less_than_or_equal_to: 10000
+                                    },
+                                    numericality: {
+                                      greater_than: 0,
+                                      less_than_or_equal_to: 100,
+                                      message: "must be greater than zero and less than $100"
+                                    }
 
   # Skip validations separately from each other
   monetize :skip_validation_price_cents, subunit_numericality: false, numericality: false, allow_nil: true
@@ -43,10 +44,11 @@ class Product < ActiveRecord::Base
   monetize :validates_method_amount_cents, allow_nil: true
 
   validates :validates_method_amount, money: {
-    greater_than: 0,
-    less_than_or_equal_to: ->(product) { product.optional_price.to_f },
-    message: 'must be greater than zero and less than $100',
-  }, allow_nil: true
+                                        greater_than: 0,
+                                        less_than_or_equal_to: ->(product) { product.optional_price.to_f },
+                                        message: 'must be greater than zero and less than $100',
+                                      },
+                                      allow_nil: true
 
   alias_attribute :renamed_cents, :aliased_cents
 

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -6,29 +6,29 @@ class Product < ActiveRecord::Base
   monetize :price_cents
 
   # Use money-rails macro with multiple fields
-  monetize :delivery_fee_cents, :restock_fee_cents, :allow_nil => true
+  monetize :delivery_fee_cents, :restock_fee_cents, allow_nil: true
 
   # Use a custom name for the Money attribute
-  monetize :discount, :as => "discount_value"
+  monetize :discount, as: "discount_value"
 
   # Allow nil
-  monetize :optional_price_cents, :allow_nil => true
+  monetize :optional_price_cents, allow_nil: true
 
   # Override default currency (EUR) with a specific one (GBP) for this field only
-  monetize :bonus_cents, :with_currency => :gbp
+  monetize :bonus_cents, with_currency: :gbp
 
   # Use currency column to determine currency for this field only
-  monetize :sale_price_amount, :as => :sale_price,
-    :with_model_currency => :sale_price_currency_code
+  monetize :sale_price_amount, as: :sale_price,
+    with_model_currency: :sale_price_currency_code
 
-  monetize :price_in_a_range_cents, :allow_nil => true,
-  :subunit_numericality => {
-    :greater_than => 0,
-  :less_than_or_equal_to => 10000 },
-  :numericality => {
-    :greater_than => 0,
-    :less_than_or_equal_to => 100,
-    :message => "must be greater than zero and less than $100"
+  monetize :price_in_a_range_cents, allow_nil: true,
+  subunit_numericality: {
+    greater_than: 0,
+  less_than_or_equal_to: 10000 },
+  numericality: {
+    greater_than: 0,
+    less_than_or_equal_to: 100,
+    message: "must be greater than zero and less than $100"
   }
 
   # Skip validations separately from each other
@@ -42,10 +42,10 @@ class Product < ActiveRecord::Base
 
   monetize :validates_method_amount_cents, allow_nil: true
 
-  validates :validates_method_amount, :money => {
-    :greater_than => 0,
-    :less_than_or_equal_to => ->(product) { product.optional_price.to_f },
-    :message => 'must be greater than zero and less than $100',
+  validates :validates_method_amount, money: {
+    greater_than: 0,
+    less_than_or_equal_to: ->(product) { product.optional_price.to_f },
+    message: 'must be greater than zero and less than $100',
   }, allow_nil: true
 
   alias_attribute :renamed_cents, :aliased_cents
@@ -53,5 +53,5 @@ class Product < ActiveRecord::Base
   monetize :renamed_cents, allow_nil: true
 
   # Using postfix to determine currency column (reduced_price_currency)
-  monetize :reduced_price_cents, :allow_nil => true
+  monetize :reduced_price_cents, allow_nil: true
 end

--- a/spec/dummy/app/models/service.rb
+++ b/spec/dummy/app/models/service.rb
@@ -1,5 +1,5 @@
 class Service < ActiveRecord::Base
-  monetize :charge_cents, :with_currency => :usd
+  monetize :charge_cents, with_currency: :usd
 
   monetize :discount_cents
 end

--- a/spec/dummy/app/models/transaction.rb
+++ b/spec/dummy/app/models/transaction.rb
@@ -1,11 +1,11 @@
 class Transaction < ActiveRecord::Base
-  monetize :amount_cents, :with_model_currency => :currency
+  monetize :amount_cents, with_model_currency: :currency
 
-  monetize :tax_cents, :with_model_currency => :currency
+  monetize :tax_cents, with_model_currency: :currency
 
-  monetize :total_cents, :with_model_currency => :currency
+  monetize :total_cents, with_model_currency: :currency
 
-  monetize :optional_amount_cents, :with_model_currency => :currency, :allow_nil => true
+  monetize :optional_amount_cents, with_model_currency: :currency, allow_nil: true
 
   def total_cents
     return amount_cents + tax_cents

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    "application", :media => "all" %>
+  <%= stylesheet_link_tag    "application", media: "all" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 </head>

--- a/spec/dummy/config/initializers/money.rb
+++ b/spec/dummy/config/initializers/money.rb
@@ -18,14 +18,14 @@ MoneyRails.configure do |config|
   # Register a custom currency
   #
   config.register_currency = {
-    :priority            => 1,
-    :iso_code            => "EU4",
-    :name                => "Euro with subunit of 4 digits",
-    :symbol              => "€",
-    :symbol_first        => true,
-    :subunit             => "Subcent",
-    :subunit_to_unit     => 10000,
-    :thousands_separator => ".",
-    :decimal_mark        => ","
+    priority:            1,
+    iso_code:            "EU4",
+    name:                "Euro with subunit of 4 digits",
+    symbol:              "€",
+    symbol_first:        true,
+    subunit:             "Subcent",
+    subunit_to_unit:     10000,
+    thousands_separator: ".",
+    decimal_mark:        ","
   }
 end

--- a/spec/dummy/config/initializers/session_store.rb
+++ b/spec/dummy/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Dummy::Application.config.session_store :cookie_store, :key => '_dummy_session'
+Dummy::Application.config.session_store :cookie_store, key: '_dummy_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/spec/dummy/config/initializers/wrap_parameters.rb
+++ b/spec/dummy/config/initializers/wrap_parameters.rb
@@ -5,7 +5,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters :format => [:json]
+  wrap_parameters format: [:json]
 end
 
 # Disable root element in JSON by default.

--- a/spec/dummy/db/migrate/20120712202655_add_sale_price_cents_to_product.rb
+++ b/spec/dummy/db/migrate/20120712202655_add_sale_price_cents_to_product.rb
@@ -1,7 +1,7 @@
 class AddSalePriceCentsToProduct < (Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
   def change
     add_column :products, :sale_price_amount, :integer,
-               :default => 0, :null => false
+               default: 0, null: false
     add_column :products, :sale_price_currency_code, :string
   end
 end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'MoneyRails::ActionViewExtension', :type => :helper do
+describe 'MoneyRails::ActionViewExtension', type: :helper do
   describe '#currency_symbol' do
     subject { helper.currency_symbol }
     it { is_expected.to be_a String }
@@ -16,7 +16,7 @@ describe 'MoneyRails::ActionViewExtension', :type => :helper do
     it { is_expected.not_to include Money.default_currency.decimal_mark }
 
     context 'with symbol options' do
-      let(:options) { { :symbol => true } }
+      let(:options) { { symbol: true } }
       it { is_expected.to include Money.default_currency.symbol }
     end
 
@@ -32,11 +32,11 @@ describe 'MoneyRails::ActionViewExtension', :type => :helper do
       let(:money_object) { Money.new(125_00, 'SGD') }
 
       context 'with symbol options' do
-        let(:options) { { :symbol => true } }
+        let(:options) { { symbol: true } }
         it { is_expected.to include Money::Currency.new(:sgd).symbol }
 
         context 'with disambiguate options' do
-          let(:options) { { :symbol => true, :disambiguate => true } }
+          let(:options) { { symbol: true, disambiguate: true } }
           it { is_expected.to include Money::Currency.new(:sgd).disambiguate_symbol }
         end
       end

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 if defined? ActiveRecord
-  describe "Test helper in form blocks", :type => :helper do
+  describe "Test helper in form blocks", type: :helper do
 
     let :product do
-      Product.create(:price_cents => 3000, :discount => 150,
-                     :bonus_cents => 200, :optional_price => 100,
-                     :sale_price_amount => 1200)
+      Product.create(price_cents: 3000, discount: 150,
+                     bonus_cents: 200, optional_price: 100,
+                     sale_price_amount: 1200)
     end
 
     context "textfield" do

--- a/spec/mongoid/five_spec.rb
+++ b/spec/mongoid/five_spec.rb
@@ -3,20 +3,20 @@ require 'spec_helper'
 if defined?(Mongoid) && ::Mongoid::VERSION =~ /^5(.*)/
 
   describe Money do
-    let!(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
-    let!(:priceable_from_num) { Priceable.create(:price => 1) }
-    let!(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
-    let!(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
+    let!(:priceable) { Priceable.create(price: Money.new(100, 'EUR')) }
+    let!(:priceable_from_num) { Priceable.create(price: 1) }
+    let!(:priceable_from_string) { Priceable.create(price: '1 EUR' )}
+    let!(:priceable_from_hash) { Priceable.create(price: {cents: 100, currency_iso: "EUR"} )}
     let!(:priceable_from_hash_with_indifferent_access) {
-      Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"}.with_indifferent_access)
+      Priceable.create(price: {cents: 100, currency_iso: "EUR"}.with_indifferent_access)
     }
-    let(:priceable_from_string_with_hyphen) { Priceable.create(:price => '1-2 EUR' )}
-    let(:priceable_from_string_with_unknown_currency) { Priceable.create(:price => '1 TLDR') }
-    let(:priceable_with_infinite_precision) { Priceable.create(:price => Money.new(BigDecimal.new('100.1'), 'EUR')) }
+    let(:priceable_from_string_with_hyphen) { Priceable.create(price: '1-2 EUR' )}
+    let(:priceable_from_string_with_unknown_currency) { Priceable.create(price: '1 TLDR') }
+    let(:priceable_with_infinite_precision) { Priceable.create(price: Money.new(BigDecimal.new('100.1'), 'EUR')) }
     let(:priceable_with_hash_field) {
-      Priceable.create(:price_hash => {
-        :key1 => Money.new(100, "EUR"),
-        :key2 => Money.new(200, "USD")
+      Priceable.create(price_hash: {
+        key1: Money.new(100, "EUR"),
+        key2: Money.new(200, "USD")
       })
     }
 
@@ -103,14 +103,14 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^5(.*)/
         expect(nil_priceable.price.currency).to eq(Money.default_currency)
       end
       it 'returns nil if an unknown value was stored' do
-        zero_priceable = Priceable.create(:price => [])
+        zero_priceable = Priceable.create(price: [])
         expect(zero_priceable.price).to be_nil
       end
     end
 
     context "evolve" do
       it "correctly transforms a Money object into a Mongo friendly value" do
-        expect(Priceable.where(:price => Money.new(100, 'EUR')).first).to eq(priceable)
+        expect(Priceable.where(price: Money.new(100, 'EUR')).first).to eq(priceable)
       end
     end
   end

--- a/spec/mongoid/four_spec.rb
+++ b/spec/mongoid/four_spec.rb
@@ -3,21 +3,21 @@ require 'spec_helper'
 if defined?(Mongoid) && ::Mongoid::VERSION =~ /^4(.*)/
 
   describe Money do
-    let!(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
-    let(:priceable_from_nil) { Priceable.create(:price => nil) }
-    let(:priceable_from_num) { Priceable.create(:price => 1) }
-    let(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
-    let(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
+    let!(:priceable) { Priceable.create(price: Money.new(100, 'EUR')) }
+    let(:priceable_from_nil) { Priceable.create(price: nil) }
+    let(:priceable_from_num) { Priceable.create(price: 1) }
+    let(:priceable_from_string) { Priceable.create(price: '1 EUR' )}
+    let(:priceable_from_hash) { Priceable.create(price: {cents: 100, currency_iso: "EUR"} )}
     let(:priceable_from_hash_with_indifferent_access) {
-      Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"}.with_indifferent_access)
+      Priceable.create(price: {cents: 100, currency_iso: "EUR"}.with_indifferent_access)
     }
-    let(:priceable_from_string_with_hyphen) { Priceable.create(:price => '1-2 EUR' )}
-    let(:priceable_from_string_with_unknown_currency) { Priceable.create(:price => '1 TLDR') }
-    let(:priceable_with_infinite_precision) { Priceable.create(:price => Money.new(BigDecimal.new('100.1'), 'EUR')) }
+    let(:priceable_from_string_with_hyphen) { Priceable.create(price: '1-2 EUR' )}
+    let(:priceable_from_string_with_unknown_currency) { Priceable.create(price: '1 TLDR') }
+    let(:priceable_with_infinite_precision) { Priceable.create(price: Money.new(BigDecimal.new('100.1'), 'EUR')) }
     let(:priceable_with_hash_field) {
-      Priceable.create(:price_hash => {
-        :key1 => Money.new(100, "EUR"),
-        :key2 => Money.new(200, "USD")
+      Priceable.create(price_hash: {
+        key1: Money.new(100, "EUR"),
+        key2: Money.new(200, "USD")
       })
     }
 
@@ -109,14 +109,14 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^4(.*)/
       end
 
       it 'returns nil if an unknown value was stored' do
-        zero_priceable = Priceable.create(:price => [])
+        zero_priceable = Priceable.create(price: [])
         expect(zero_priceable.price).to be_nil
       end
     end
 
     context "evolve" do
       it "correctly transforms a Money object into a Mongo friendly value" do
-        expect(Priceable.where(:price => Money.new(100, 'EUR')).first).to eq(priceable)
+        expect(Priceable.where(price: Money.new(100, 'EUR')).first).to eq(priceable)
       end
     end
   end

--- a/spec/mongoid/three_spec.rb
+++ b/spec/mongoid/three_spec.rb
@@ -3,21 +3,21 @@ require 'spec_helper'
 if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
 
   describe Money do
-    let!(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
-    let(:priceable_from_nil) { Priceable.create(:price => nil) }
-    let(:priceable_from_num) { Priceable.create(:price => 1) }
-    let(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
-    let(:priceable_from_hash) { Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"} )}
+    let!(:priceable) { Priceable.create(price: Money.new(100, 'EUR')) }
+    let(:priceable_from_nil) { Priceable.create(price: nil) }
+    let(:priceable_from_num) { Priceable.create(price: 1) }
+    let(:priceable_from_string) { Priceable.create(price: '1 EUR' )}
+    let(:priceable_from_hash) { Priceable.create(price: {cents: 100, currency_iso: "EUR"} )}
     let(:priceable_from_hash_with_indifferent_access) {
-      Priceable.create(:price => {:cents=>100, :currency_iso=>"EUR"}.with_indifferent_access)
+      Priceable.create(price: {cents: 100, currency_iso: "EUR"}.with_indifferent_access)
     }
-    let(:priceable_from_string_with_hyphen) { Priceable.create(:price => '1-2 EUR' )}
-    let(:priceable_from_string_with_unknown_currency) { Priceable.create(:price => '1 TLDR') }
-    let(:priceable_with_infinite_precision) { Priceable.create(:price => Money.new(BigDecimal.new('100.1'), 'EUR')) }
+    let(:priceable_from_string_with_hyphen) { Priceable.create(price: '1-2 EUR' )}
+    let(:priceable_from_string_with_unknown_currency) { Priceable.create(price: '1 TLDR') }
+    let(:priceable_with_infinite_precision) { Priceable.create(price: Money.new(BigDecimal.new('100.1'), 'EUR')) }
     let(:priceable_with_hash_field) {
-      Priceable.create(:price_hash => {
-        :key1 => Money.new(100, "EUR"),
-        :key2 => Money.new(200, "USD")
+      Priceable.create(price_hash: {
+        key1: Money.new(100, "EUR"),
+        key2: Money.new(200, "USD")
       })
     }
 
@@ -108,14 +108,14 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^3(.*)/
       end
 
       it 'returns nil if an unknown value was stored' do
-        zero_priceable = Priceable.create(:price => [])
+        zero_priceable = Priceable.create(price: [])
         expect(zero_priceable.price).to be_nil
       end
     end
 
     context "evolve" do
       it "transforms correctly a Money object to a Mongo friendly value" do
-        expect(Priceable.where(:price => Money.new(100, 'EUR')).first).to eq(priceable)
+        expect(Priceable.where(price: Money.new(100, 'EUR')).first).to eq(priceable)
       end
     end
   end

--- a/spec/mongoid/two_spec.rb
+++ b/spec/mongoid/two_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 if defined?(Mongoid) && ::Mongoid::VERSION =~ /^2(.*)/
 
   describe Money do
-    let(:priceable) { Priceable.create(:price => Money.new(100, 'EUR')) }
-    let(:priceable_from_nil) { Priceable.create(:price => nil) }
-    let(:priceable_from_num) { Priceable.create(:price => 1) }
-    let(:priceable_from_string) { Priceable.create(:price => '1 EUR' )}
-    let(:priceable_with_infinite_precision) { Priceable.create(:price => Money.new(BigDecimal.new('100.1'), 'EUR')) }
-    let(:priceable_from_string_with_hyphen) { Priceable.create(:price => '1-2 EUR' )}
+    let(:priceable) { Priceable.create(price: Money.new(100, 'EUR')) }
+    let(:priceable_from_nil) { Priceable.create(price: nil) }
+    let(:priceable_from_num) { Priceable.create(price: 1) }
+    let(:priceable_from_string) { Priceable.create(price: '1 EUR' )}
+    let(:priceable_with_infinite_precision) { Priceable.create(price: Money.new(BigDecimal.new('100.1'), 'EUR')) }
+    let(:priceable_from_string_with_hyphen) { Priceable.create(price: '1-2 EUR' )}
 
     context "serialize" do
       it "mongoizes correctly nil to nil" do
@@ -72,7 +72,7 @@ if defined?(Mongoid) && ::Mongoid::VERSION =~ /^2(.*)/
       end
 
       it 'returns nil if an unknown value was stored' do
-        zero_priceable = Priceable.create(:price => [])
+        zero_priceable = Priceable.create(price: [])
         expect(zero_priceable.price).to be_nil
       end
     end

--- a/spec/test_helpers_spec.rb
+++ b/spec/test_helpers_spec.rb
@@ -8,9 +8,9 @@ if defined? ActiveRecord
     include MoneyRails::TestHelpers
 
     let(:product) do
-      Product.create(:price_cents => 3000, :discount => 150,
-                     :bonus_cents => 200,
-                     :sale_price_amount => 1200)
+      Product.create(price_cents: 3000, discount: 150,
+                     bonus_cents: 200,
+                     sale_price_amount: 1200)
     end
 
     describe "monetize matcher" do


### PR DESCRIPTION
Since we aren't supporting ruby < 1.9, I'm switching the codebase to the new hash syntax to avoid inconsistencies in the code style