### PR TITLE
Make money-rails compatible with money 6.11

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -23,7 +23,7 @@ module MoneyRails
         return if options[:allow_nil] && @raw_value.nil?
 
         # Set this before we modify @raw_value below.
-        stringy = @raw_value.present? && !@raw_value.is_a?(Numeric)
+        stringy = @raw_value.present? && !@raw_value.is_a?(Numeric) && !@raw_value.is_a?(Money)
 
         if stringy
           # remove currency symbol

--- a/lib/money-rails/money.rb
+++ b/lib/money-rails/money.rb
@@ -2,25 +2,23 @@ require "active_support/core_ext/module/aliasing.rb"
 require "active_support/core_ext/hash/reverse_merge.rb"
 
 class Money
-  alias_method :orig_format, :format
+  class <<self
+    alias_method :orig_default_formatting_rules, :default_formatting_rules
 
-  def format(*rules)
-    rules = normalize_formatting_rules(rules)
+    def default_formatting_rules
+      rules = orig_default_formatting_rules || {}
+      defaults = {
+        no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole,
+        symbol: MoneyRails::Configuration.symbol,
+        sign_before_symbol: MoneyRails::Configuration.sign_before_symbol
+      }.reject { |_k, v| v.nil? }
 
-    # Apply global defaults for money only for non-nil values
-    defaults = {
-      no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole,
-      symbol: MoneyRails::Configuration.symbol,
-      sign_before_symbol: MoneyRails::Configuration.sign_before_symbol
-    }.reject { |_k, v| v.nil? }
+      rules.reverse_merge!(defaults)
 
-    rules.reverse_merge!(defaults)
-
-    unless MoneyRails::Configuration.default_format.nil?
-      rules.reverse_merge!(MoneyRails::Configuration.default_format)
+      unless MoneyRails::Configuration.default_format.nil?
+        rules.reverse_merge!(MoneyRails::Configuration.default_format)
+      end
+      rules
     end
-
-    orig_format(rules)
   end
-
 end

--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_dependency "money",         "~> 6.10.0"
+  s.add_dependency "money",         "~> 6.11.0"
   s.add_dependency "monetize",      "~> 1.7.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"


### PR DESCRIPTION
This PR should fix the issues with #523.

I must admit I'm not very familiar with Money so I would appreciate code review in case this is wrong, but the tests do pass with these changes (on rails50 at least).

Changes I've made:

1. Override Money 6.11's public accessor for `default_formatting_rules`. You may prefer to assign this directly rather than override it? This replaces the monkeypatch that was in there before.
2. Check for a `Money` type coming back from `before_type_cast` when checking to see if something is stringy. This apparently fixes some I18n issues that the tests flagged up.