### PR TITLE
Fix no cents if whole configuration

### DIFF
--- a/lib/money-rails/helpers/action_view_extension.rb
+++ b/lib/money-rails/helpers/action_view_extension.rb
@@ -9,14 +9,13 @@ module MoneyRails
       if !options || !options.is_a?(Hash)
         warn "humanized_money now takes a hash of formatting options, please specify { symbol: true }"
         options = { symbol: options }
+      else
+        options = {
+          no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole == false ? false : true,
+          symbol: false
+        }.merge(options)
       end
-
-      options = {
-        no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole.nil? ? true : MoneyRails::Configuration.no_cents_if_whole,
-        symbol: false
-      }.merge(options)
       options.delete(:symbol) if options[:disambiguate]
-
       if value.is_a?(Money)
         value.format(options)
       elsif value.respond_to?(:to_money)

--- a/lib/money-rails/helpers/action_view_extension.rb
+++ b/lib/money-rails/helpers/action_view_extension.rb
@@ -9,12 +9,11 @@ module MoneyRails
       if !options || !options.is_a?(Hash)
         warn "humanized_money now takes a hash of formatting options, please specify { symbol: true }"
         options = { symbol: options }
-      else
-        options = {
-          no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole == false ? false : true,
-          symbol: false
-        }.merge(options)
       end
+      options = {
+        no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole == false ? false : true,
+        symbol: false
+      }.merge(options)
       options.delete(:symbol) if options[:disambiguate]
       if value.is_a?(Money)
         value.format(options)

--- a/lib/money-rails/helpers/action_view_extension.rb
+++ b/lib/money-rails/helpers/action_view_extension.rb
@@ -10,11 +10,13 @@ module MoneyRails
         warn "humanized_money now takes a hash of formatting options, please specify { symbol: true }"
         options = { symbol: options }
       end
+
       options = {
         no_cents_if_whole: MoneyRails::Configuration.no_cents_if_whole == false ? false : true,
         symbol: false
       }.merge(options)
       options.delete(:symbol) if options[:disambiguate]
+
       if value.is_a?(Money)
         value.format(options)
       elsif value.respond_to?(:to_money)

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -125,6 +125,38 @@ describe 'MoneyRails::ActionViewExtension', type: :helper do
       end
     end
 
+    context 'with no_cents_if_whole: false' do
+
+      before do
+        MoneyRails.configure do |config|
+          config.no_cents_if_whole = false
+        end
+      end
+
+      around(:each) do |example|
+        I18n.with_locale(:it) do
+          example.run
+        end
+      end
+
+      describe '#humanized_money' do
+        subject { helper.humanized_money Money.new(12500) }
+        it { is_expected.to be_a String }
+        it { is_expected.to include Money.default_currency.decimal_mark }
+        it { is_expected.not_to include Money.default_currency.symbol }
+        it { is_expected.to include "00" }
+      end
+
+      describe '#humanized_money_with_symbol' do
+        subject { helper.humanized_money_with_symbol Money.new(12500) }
+        it { is_expected.to be_a String }
+        it { is_expected.to include Money.default_currency.decimal_mark }
+        it { is_expected.to include Money.default_currency.symbol }
+        it { is_expected.to include "00" }
+      end
+    end
+
+
     context 'with no_cents_if_whole: true' do
 
       before do


### PR DESCRIPTION
Setting `no_cents_if_whole` in `money.rb` configuration does not preserve cents in `humanized_money` if the currency is whole (i.e. 125)

I had to include `I18n.with_locale(:it)` in the tests I added because of locale issues. My computer would set decimal mark to `"."`. I assume it is because I'm in the US.

Let me know if there is anything you'd like me to change.