### PR TITLE
Minor tweak to boolean operators

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -33,10 +33,10 @@ module MoneyRails
         normalize_raw_value!
         super(@record, @attr, @raw_value)
 
-        if stringy and record_does_not_have_error?
+        if stringy && record_does_not_have_error?
           add_error if
-            value_has_too_many_decimal_points or
-            thousand_separator_after_decimal_mark or
+            value_has_too_many_decimal_points ||
+            thousand_separator_after_decimal_mark ||
             invalid_thousands_separation
         end
       end


### PR DESCRIPTION
In Ruby, `&&` and `||` have higher precedence over `and` and `or`. Because of this, `&&` and `||` are recommended for logical operations, while `and` and `or` are more appropriate for control flow. 

[Here](https://www.tinfoilsecurity.com/blog/ruby-demystified-and-vs) is one of many articles that articulate the difference well.