### PR TITLE
bump money version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.13.0
+
+- Bump money version to ~> 6.13.0
+
 ## 1.12.0
 
 - Bump money version to ~> 6.12.0

--- a/lib/money-rails/version.rb
+++ b/lib/money-rails/version.rb
@@ -1,3 +1,3 @@
 module MoneyRails
-  VERSION = '1.12.0'
+  VERSION = '1.13.0'
 end

--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_dependency "money",         "~> 6.12.0"
+  s.add_dependency "money",         "~> 6.13.0"
   s.add_dependency "monetize",      "~> 1.9.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"


### PR DESCRIPTION
This PR bumps the version of money gem to 6.13.0 and bumps also the version of the gem itself.