### PR TITLE
update version of gem added to Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ welcome to contribute to the project.
 
 Add this line to your application's Gemfile:
 
-    gem 'money-rails', '~>1'
+    gem 'money-rails', '~>1.12'
 
 And then execute:
 


### PR DESCRIPTION
if user added gem 'money-rails', '~>1' they may get error mentioned in https://github.com/RubyMoney/money-rails/issues/524 version which was fixed later (in 1.11.0)