### PR TITLE
Using Money.locale_backend instead of Money.use_i18n and providing downward compatibility

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -62,16 +62,20 @@ module MoneyRails
 
       def decimal_mark
         character = currency.decimal_mark || '.'
-        @_decimal_mark ||= Money.use_i18n ? I18n.t('number.currency.format.separator', default: character) : character
+        @_decimal_mark ||= use_backend_locale? ? I18n.t('number.currency.format.separator', default: character) : character
       end
 
       def thousands_separator
         character = currency.thousands_separator || ','
-        @_thousands_separator ||= Money.use_i18n ? I18n.t('number.currency.format.delimiter', default: character) : character
+        @_thousands_separator ||= use_backend_locale? ? I18n.t('number.currency.format.delimiter', default: character) : character
       end
 
       def symbol
-        @_symbol ||= Money.use_i18n ? I18n.t('number.currency.format.unit', default: currency.symbol) : currency.symbol
+        @_symbol ||= use_backend_locale? ? I18n.t('number.currency.format.unit', default: currency.symbol) : currency.symbol
+      end
+
+      def use_backend_locale?
+        Money.locale_backend.present? || Money.use_i18n
       end
 
       def abs_raw_value

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -767,9 +767,42 @@ if defined? ActiveRecord
             end
           end
 
+          context "when locale_backend is true" do
+            around(:each) do |example|
+              begin
+                Money.locale_backend = :i18n
+                Money.use_i18n = false
+                example.run
+              ensure
+                Money.locale_backend = nil
+                Money.use_i18n = true
+              end
+            end
+            it "validates with the locale's decimal mark" do
+              transaction.amount = "123,45"
+              expect(transaction.valid?).to be_truthy
+            end
+
+            it "does not validate with the currency's decimal mark" do
+              transaction.amount = "123.45"
+              expect(transaction.valid?).to be_falsey
+            end
+
+            it "validates with the locale's currency symbol" do
+              transaction.amount = "€123"
+              expect(transaction.valid?).to be_truthy
+            end
+
+            it "does not validate with the transaction's currency symbol" do
+              transaction.amount = "$123.45"
+              expect(transaction.valid?).to be_falsey
+            end
+          end
+
           context "when use_i18n is false" do
             around(:each) do |example|
               begin
+                Money.locale_backend = nil
                 Money.use_i18n = false
                 example.run
               ensure

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -18,8 +18,8 @@ describe "configuration" do
     end
 
     it "sets no_cents_if_whole value for formatted output globally" do
-      # Disable the usage of I18n (to avoid default symbols for :en)
-      Money.use_i18n = false
+      # Enable formatting to depend only on currency (to avoid default symbols for :en)
+      Money.locale_backend = :currency
 
       value = Money.new(12345600, "EUR")
       mark = Money::Currency.find(:eur).decimal_mark
@@ -35,7 +35,7 @@ describe "configuration" do
 
       # Reset global settings
       MoneyRails.no_cents_if_whole = nil
-      Money.use_i18n = true
+      Money.locale_backend = :i18n
     end
 
     it "sets symbol for formatted output globally" do


### PR DESCRIPTION
**Problem:**
The latest version of the money gem deprecates the use of `Money.use_i18n` and suggests using `Money.locale_backend`. For that reason we updated our configuration as follows:
```
Money.use_i18n = false        # We did this to avoid deprecation warnings see https://github.com/RubyMoney/money/issues/828
Money.locale_backend = :i18n
```
Since money-rails currently does not check for `Money.locale_backend` this caused the thousands_separator and the delimiter to be sourced from the currency locale. Now this normally should not cause problems as long as the thousands_separators and delimiters are identical.
But we were using an english language locale and a euro currency locale, which do not share the same delimiters and operators and caused the following validation to fail.

```
def thousand_separator_after_decimal_mark
  thousands_separator.present? && decimal_pieces.length == 2 && decimal_pieces[1].include?(thousands_separator)
end
```

**Solution:**
To fix this behaviour I introduced `use_backend_locale?` that checks if `Money.backend_locale` is set and only calls `Money.use_i18n` as a fallback to provide downwards compatibility.
Additionally this should fix deprecation warnings for people who set up their project using `Money.locale_backend`.

**Tests:**
I added tests for the new behaviour but did not adjust all the existing tests to use Money.locale_backend. Let me know if this is necessary


