### PR TITLE
Fix failing master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 before_install:
-  - gem update --system
+  # Rubygems > 3.0.0 no longer supported rubies < 2.3
+  - gem install "rubygems-update:<3.0.0" --no-document && update_rubygems
   - gem update bundler
 before_script:
   - "bundle exec rake prepare_test_env"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 before_install:
   # Rubygems > 3.0.0 no longer supported rubies < 2.3
   - gem install "rubygems-update:<3.0.0" --no-document && update_rubygems
-  - gem update bundler
+  # Bundler 2.0 is not supported by Rails < 5
+  - gem list -i bundler -v '>= 2.0.0' && rvm @global do gem uninstall bundler -x || true
+  - gem install bundler -v '~> 1.17'
 before_script:
   - "bundle exec rake prepare_test_env"
 script: "bundle exec rspec"

--- a/gemfiles/mongoid2.gemfile
+++ b/gemfiles/mongoid2.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'mongoid', '~> 2.5'
+gem 'rails',   '~> 3.1'
 gem 'i18n',    '~> 0.6.9'
 
 platforms :jruby do

--- a/gemfiles/mongoid3.gemfile
+++ b/gemfiles/mongoid3.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'mongoid', '~> 3.1'
+gem 'rails',   '~> 3.2'
 gem 'i18n',    '~> 0.6.9'
 
 platforms :jruby do

--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -44,8 +44,7 @@ module MoneyRails
       private
 
       def record_does_not_have_error?
-        return true unless @record.errors.has_key?(@attr)
-        !@record.errors.added?(@attr, :not_a_number)
+        !@record.errors.added?(@attr, :not_a_number, value: @raw_value)
       end
 
       def reset_memoized_variables!


### PR DESCRIPTION
Seem that `ActiveModel::Errors#added?` will only return false when querying for specific message and options:

```ruby
@record.errors.details
=> { :price => { :error => :not_a_number, :value => "12.23.24" } }

@record.errors.added?(@attr, :not_a_number)
=> false

@record.errors.added?(@attr, :not_a_number, value: "12.23.24")
=> true
```

Looks like this was changed recently since all our specs remained intact. But this works across all supported versions on Rails, so sticking to it for now.