### PR TITLE
Add linebreaks/bullet points to 1.13.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 1.13.1
 
-Add a guard clause for "blank form" input (Mongoid)
-Do not add extra errors in case attribute is not a number
-Use Money.locale_backend instead of Money.use_i18n
-Add money_only_cents helper method
+- Add a guard clause for "blank form" input (Mongoid)
+- Do not add extra errors in case attribute is not a number
+- Use Money.locale_backend instead of Money.use_i18n
+- Add money_only_cents helper method
 
 ## 1.13.0
 


### PR DESCRIPTION
Was all rendered in one line otherwise which is confusing. Thanks for the quick release.