### PR TITLE
Lock sqlite3 to ~> 1.3.6, so specs run smoothly

### DIFF
--- a/gemfiles/mongoid2.gemfile
+++ b/gemfiles/mongoid2.gemfile
@@ -12,7 +12,7 @@ end
 
 platforms :ruby do
   gem "bson_ext"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec path: '../'

--- a/gemfiles/mongoid3.gemfile
+++ b/gemfiles/mongoid3.gemfile
@@ -11,7 +11,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec path: '../'

--- a/gemfiles/mongoid4.gemfile
+++ b/gemfiles/mongoid4.gemfile
@@ -11,7 +11,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec path: '../'

--- a/gemfiles/mongoid5.gemfile
+++ b/gemfiles/mongoid5.gemfile
@@ -11,7 +11,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec path: '../'

--- a/gemfiles/mongoid6.gemfile
+++ b/gemfiles/mongoid6.gemfile
@@ -11,7 +11,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec path: '../'

--- a/gemfiles/mongoid7.gemfile
+++ b/gemfiles/mongoid7.gemfile
@@ -11,7 +11,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec path: '../'

--- a/gemfiles/rails3.gemfile
+++ b/gemfiles/rails3.gemfile
@@ -10,7 +10,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec path: '../'

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -9,7 +9,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec path: '../'

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -9,7 +9,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec path: '../'

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0'
+gem 'i18n',  '< 1.5'
 
 platforms :jruby do
   gem "activerecord-jdbc-adapter"


### PR DESCRIPTION
With unlocked sqlite3 I had issues running specs, namely errors like this:
```
LoadError: Please install the sqlite3 adapter: `gem install activerecord-sqlite3-adapter` (can't activate sqlite3 (~> 1.3.5), already activated sqlite3-1.4.0. Make sure all dependencies are added to Gemfile.)
```

Now I can successfully run all the specs, yay!