### PR TITLE
Make validation compatible with Money.locale_backend

### DIFF
--- a/lib/money-rails/configuration.rb
+++ b/lib/money-rails/configuration.rb
@@ -7,7 +7,6 @@ module MoneyRails
   # MoneyRails configuration module.
   # This is extended by MoneyRails to provide configuration settings.
   module Configuration
-
     # Start a MoneyRails configuration block in an initializer.
     #
     # example: Provide a default currency for the application
@@ -59,7 +58,7 @@ module MoneyRails
     #   MoneyRails.configure do |config|
     #     config.default_bank = EuCentralBank.new
     #   end
-    delegate :default_bank=, :default_bank, to: :Money
+    delegate :default_bank=, :default_bank, :locale_backend, :locale_backend=, to: :Money
 
     # Provide exchange rates
     delegate :add_rate, to: :Money

--- a/lib/money-rails/money.rb
+++ b/lib/money-rails/money.rb
@@ -2,7 +2,7 @@ require "active_support/core_ext/module/aliasing.rb"
 require "active_support/core_ext/hash/reverse_merge.rb"
 
 class Money
-  class <<self
+  class << self
     alias_method :orig_default_formatting_rules, :default_formatting_rules
 
     def default_formatting_rules

--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_dependency "money",         "~> 6.13.0"
+  s.add_dependency "money",         "~> 6.13.2"
   s.add_dependency "monetize",      "~> 1.9.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -738,6 +738,8 @@ if defined? ActiveRecord
           end
         end
 
+        # TODO: these specs should mock locale_backend with expected values
+        #       instead of manipulating it directly
         context "and an Italian locale" do
           around(:each) do |example|
             I18n.with_locale(:it) do
@@ -745,7 +747,7 @@ if defined? ActiveRecord
             end
           end
 
-          context "when use_i18n is true" do
+          context "when using :i18n locale backend" do
             it "validates with the locale's decimal mark" do
               transaction.amount = "123,45"
               expect(transaction.valid?).to be_truthy
@@ -767,46 +769,13 @@ if defined? ActiveRecord
             end
           end
 
-          context "when locale_backend is true" do
+          context "when using :currency locale backend" do
             around(:each) do |example|
               begin
+                Money.locale_backend = :currency
+                example.run
+              ensure
                 Money.locale_backend = :i18n
-                Money.use_i18n = false
-                example.run
-              ensure
-                Money.locale_backend = nil
-                Money.use_i18n = true
-              end
-            end
-            it "validates with the locale's decimal mark" do
-              transaction.amount = "123,45"
-              expect(transaction.valid?).to be_truthy
-            end
-
-            it "does not validate with the currency's decimal mark" do
-              transaction.amount = "123.45"
-              expect(transaction.valid?).to be_falsey
-            end
-
-            it "validates with the locale's currency symbol" do
-              transaction.amount = "€123"
-              expect(transaction.valid?).to be_truthy
-            end
-
-            it "does not validate with the transaction's currency symbol" do
-              transaction.amount = "$123.45"
-              expect(transaction.valid?).to be_falsey
-            end
-          end
-
-          context "when use_i18n is false" do
-            around(:each) do |example|
-              begin
-                Money.locale_backend = nil
-                Money.use_i18n = false
-                example.run
-              ensure
-                Money.use_i18n = true
               end
             end
 


### PR DESCRIPTION
This will use `Money.locale_backend` for looking up locale-specific values instead of figuring them out directly. This should make validations compatible with `Money.locale_backend` settings.