### PR TITLE
Add locale_backend default + comments to template

### DIFF
--- a/lib/generators/templates/money.rb
+++ b/lib/generators/templates/money.rb
@@ -105,8 +105,6 @@ MoneyRails.configure do |config|
   # In case you don't need localization and would like to use default values
   # (can be redefined using config.default_format):
   # config.locale_backend = nil
-  #
-  config.locale_backend = nil
 
   # Set default raise_error_on_money_parsing option
   # It will be raise error if assigned different currency

--- a/lib/generators/templates/money.rb
+++ b/lib/generators/templates/money.rb
@@ -83,6 +83,31 @@ MoneyRails.configure do |config|
   #   sign_before_symbol: nil
   # }
 
+  # If you would like to use I18n localization (formatting depends on the
+  # locale):
+  # config.locale_backend = :i18n
+  #
+  # Example (using default localization from rails-i18n):
+  #
+  # I18n.locale = :en
+  # Money.new(10_000_00, 'USD').format # => $10,000.00
+  # I18n.locale = :es
+  # Money.new(10_000_00, 'USD').format # => $10.000,00
+  #
+  # For the legacy behaviour of "per currency" localization (formatting depends
+  # only on currency):
+  # config.locale_backend = :currency
+  #
+  # Example:
+  # Money.new(10_000_00, 'USD').format # => $10,000.00
+  # Money.new(10_000_00, 'EUR').format # => €10.000,00
+  #
+  # In case you don't need localization and would like to use default values
+  # (can be redefined using config.default_format):
+  # config.locale_backend = nil
+  #
+  config.locale_backend = nil
+
   # Set default raise_error_on_money_parsing option
   # It will be raise error if assigned different currency
   # The default value is false


### PR DESCRIPTION
Per https://github.com/RubyMoney/money#deprecation the default behavior
of checking i18n locale and falling back to per-currency localization
will be deprecated. This results in a deprecation message when
`locale_backend` has not been set.

This commit explicitly sets `config.locale_backend` to `nil` and adds
comments to turn on Money format localization.

Fixes #569 