### PR TITLE
Set TravisCI dist to Trusty for ruby 1.9.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 before_install:
   # Rubygems > 3.0.0 no longer supported rubies < 2.3
   - gem install "rubygems-update:<3.0.0" --no-document && update_rubygems


### PR DESCRIPTION
Fix failing 1.9.3 builds