### PR TITLE
Make remove_money reversible with db:rollback

### DIFF
--- a/lib/money-rails/active_record/migration_extensions/schema_statements_pg_rails4.rb
+++ b/lib/money-rails/active_record/migration_extensions/schema_statements_pg_rails4.rb
@@ -11,8 +11,8 @@ module MoneyRails
 
         def remove_monetize(table_name, accessor, options={})
           [:amount, :currency].each do |attribute|
-            column_present, table_name, column_name, _, _ =  OptionsExtractor.extract attribute, table_name, accessor, options
-            remove_column table_name, column_name if column_present
+            column_present, table_name, column_name, type, _ =  OptionsExtractor.extract attribute, table_name, accessor, options
+            remove_column table_name, column_name, type if column_present
           end
         end
       end


### PR DESCRIPTION
Update schema_statements_pg_rails4.rb to make `remove_monetize` / `remove_money` reversible (which is useful with `rails db:rollback`).

(Otherwise you get a ActiveRecord::IrreversibleMigration with message: "remove_column is only reversible if given a type.")