### PR TITLE
Support editing of Money fields in Rails Admin

### DIFF
--- a/lib/money-rails/rails_admin.rb
+++ b/lib/money-rails/rails_admin.rb
@@ -8,7 +8,7 @@ module RailsAdmin
   module Config
     module Fields
       module Types
-        class Money < RailsAdmin::Config::Fields::Types::String
+        class Money < RailsAdmin::Config::Fields::Types::Decimal
           RailsAdmin::Config::Fields::Types::register(self)
 
           register_instance_option :pretty_value do

--- a/lib/money-rails/rails_admin.rb
+++ b/lib/money-rails/rails_admin.rb
@@ -8,7 +8,7 @@ module RailsAdmin
   module Config
     module Fields
       module Types
-        class Money < RailsAdmin::Config::Fields::Types::Integer
+        class Money < RailsAdmin::Config::Fields::Types::String
           RailsAdmin::Config::Fields::Types::register(self)
 
           register_instance_option :pretty_value do


### PR DESCRIPTION
This solves the issue of being unable to edit the cents in a Money field.

As an example, consider this config for a Money field in Rails Admin for use with database columns `price_cents` and `price_currency`:

```ruby
configure :price, :money
exclude_fields :price_cents, :price_currency
```

Attempting to edit the field results in the following error because of the `Integer` field type.

![image](https://user-images.githubusercontent.com/299357/70558043-57516e00-1b41-11ea-95ad-971e5075bb03.png)

Changing the `Money` field type to extend `String` instead of `Integer` solves this issue.