### PR TITLE
Fix validator race condition

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -2,43 +2,54 @@ module MoneyRails
   module ActiveModel
     class MoneyValidator < ::ActiveModel::Validations::NumericalityValidator
       def validate_each(record, attr, _value)
-        reset_memoized_variables!
-        @record = record
-        @attr = attr
-
-        subunit_attr = @record.class.monetized_attributes[@attr.to_s]
+        subunit_attr = record.class.monetized_attributes[attr.to_s]
+        currency = record.public_send("currency_for_#{attr}")
 
         # WARNING: Currently this is only defined in ActiveRecord extension!
-        before_type_cast = :"#{@attr}_money_before_type_cast"
-        @raw_value = @record.try(before_type_cast)
+        before_type_cast = :"#{attr}_money_before_type_cast"
+        raw_value = record.try(before_type_cast)
 
         # If raw value is nil and changed subunit is nil, then
         # nil is a assigned value, else we should treat the
         # subunit value as the one assigned.
-        if @raw_value.nil? && @record.public_send(subunit_attr)
-          subunit_value = @record.public_send(subunit_attr)
-          @raw_value = subunit_value.to_f / currency.subunit_to_unit
+        if raw_value.nil? && record.public_send(subunit_attr)
+          subunit_value = record.public_send(subunit_attr)
+          raw_value = subunit_value.to_f / currency.subunit_to_unit
         end
 
-        return if options[:allow_nil] && @raw_value.nil?
+        return if options[:allow_nil] && raw_value.nil?
 
-        # Set this before we modify @raw_value below.
-        stringy = @raw_value.present? && !@raw_value.is_a?(Numeric) && !@raw_value.is_a?(Money)
+        # Set this before we modify raw_value below.
+        stringy = raw_value.present? && !raw_value.is_a?(Numeric) && !raw_value.is_a?(Money)
 
         if stringy
+          # TODO: This is supporting legacy behaviour where a symbol can come from a i18n locale,
+          #       however practical implications of that are most likely non-existent
+          symbol = lookup(:symbol, currency) || currency.symbol
+
           # remove currency symbol
-          @raw_value = @raw_value.to_s.gsub(symbol, "")
+          raw_value = raw_value.to_s.gsub(symbol, "")
         end
 
-        normalize_raw_value!
-        super(@record, @attr, @raw_value)
+        # Cache abs_raw_value before normalizing because it's used in
+        # many places and relies on the original raw_value.
+        abs_raw_value = raw_value.to_s.sub(/^\s*-/, "").strip
+        thousands_separator = lookup(:thousands_separator, currency)
+        decimal_mark = lookup(:decimal_mark, currency)
 
-        if stringy && record_does_not_have_error?
-          add_error if
-            value_has_too_many_decimal_points ||
-            thousand_separator_after_decimal_mark ||
-            invalid_thousands_separation
-        end
+        raw_value = normalize_raw_value(raw_value, thousands_separator, decimal_mark)
+
+        super(record, attr, raw_value)
+
+        return unless stringy
+        return if record_already_has_error?(record, attr, raw_value)
+
+        decimal_pieces = abs_raw_value.split(decimal_mark)
+
+        add_error!(record, attr, thousands_separator, decimal_mark, abs_raw_value) if
+          value_has_too_many_decimal_points(decimal_pieces) ||
+          thousand_separator_after_decimal_mark(decimal_pieces, thousands_separator) ||
+          invalid_thousands_separation(decimal_pieces, thousands_separator)
       end
 
       private
@@ -48,70 +59,36 @@ module MoneyRails
         thousands_separator: ','
       }.freeze
 
-      def record_does_not_have_error?
-        !@record.errors.added?(@attr, :not_a_number, value: @raw_value)
+      def record_already_has_error?(record, attr, raw_value)
+        record.errors.added?(attr, :not_a_number, value: raw_value)
       end
 
-      def reset_memoized_variables!
-        [:currency, :decimal_mark, :thousands_separator, :symbol,
-          :abs_raw_value, :decimal_pieces, :pieces_array].each do |var_name|
-          ivar_name = :"@_#{var_name}"
-          remove_instance_variable(ivar_name) if instance_variable_defined?(ivar_name)
-        end
+      def add_error!(record, attr, thousands_separator, decimal_mark, abs_raw_value)
+        attr_name = attr.to_s.tr('.', '_').humanize
+        attr_name = record.class.human_attribute_name(attr, default: attr_name)
+
+        record.errors.add(attr, :invalid_currency, {
+          thousands: thousands_separator,
+          decimal: decimal_mark,
+          currency: abs_raw_value,
+          attribute: attr_name
+        })
       end
 
-      def currency
-        @_currency ||= @record.public_send("currency_for_#{@attr}")
-      end
-
-      def decimal_mark
-        @_decimal_mark ||= lookup(:decimal_mark)
-      end
-
-      def thousands_separator
-        @_thousands_separator ||= lookup(:thousands_separator)
-      end
-
-      # TODO: This is supporting legacy behaviour where a symbol can come from a i18n locale,
-      #       however practical implications of that are most likely non-existent
-      def symbol
-        @_symbol ||= lookup(:symbol) || currency.symbol
-      end
-
-      def abs_raw_value
-        @_abs_raw_value ||= @raw_value.to_s.sub(/^\s*-/, "").strip
-      end
-
-      def add_error
-        attr_name = @attr.to_s.tr('.', '_').humanize
-        attr_name = @record.class.human_attribute_name(@attr, default: attr_name)
-
-        @record.errors.add(@attr, :invalid_currency,
-                           { thousands: thousands_separator,
-                             decimal: decimal_mark,
-                             currency: abs_raw_value,
-                             attribute: attr_name })
-      end
-
-      def decimal_pieces
-        @_decimal_pieces ||= abs_raw_value.split(decimal_mark)
-      end
-
-      def value_has_too_many_decimal_points
+      def value_has_too_many_decimal_points(decimal_pieces)
         ![1, 2].include?(decimal_pieces.length)
       end
 
-      def pieces_array
-        @_pieces_array ||= decimal_pieces[0].split(thousands_separator.presence)
-      end
-
-      def thousand_separator_after_decimal_mark
+      def thousand_separator_after_decimal_mark(decimal_pieces, thousands_separator)
         thousands_separator.present? && decimal_pieces.length == 2 && decimal_pieces[1].include?(thousands_separator)
       end
 
-      def invalid_thousands_separation
+      def invalid_thousands_separation(decimal_pieces, thousands_separator)
+        pieces_array = decimal_pieces[0].split(thousands_separator.presence)
+
         return false if pieces_array.length <= 1
         return true  if pieces_array[0].length > 3
+
         pieces_array[1..-1].any? do |thousands_group|
           thousands_group.length != 3
         end
@@ -119,18 +96,15 @@ module MoneyRails
 
       # Remove thousands separators, normalize decimal mark,
       # remove whitespaces and _ (E.g. 99 999 999 or 12_300_200.20)
-      def normalize_raw_value!
-        # Cache abs_raw_value before normalizing because it's used in
-        # many places and relies on the original @raw_value.
-        abs_raw_value
-
-        @raw_value = @raw_value.to_s
+      def normalize_raw_value(raw_value, thousands_separator, decimal_mark)
+        raw_value
+          .to_s
           .gsub(thousands_separator, '')
           .gsub(decimal_mark, '.')
           .gsub(/[\s_]/, '')
       end
 
-      def lookup(key)
+      def lookup(key, currency)
         if locale_backend
           locale_backend.lookup(key, currency) || DEFAULTS[key]
         else


### PR DESCRIPTION
Rails caches validator instances on model classes, which makes it unsafe to cache any model instance specific data on the validator. In a threaded environment lots of issues can happen because of this, e.g. `@record` can get changed on the validator when validating 2 different models at the same time.

This PR rewrites the validators to remove any memoization. The future plan for this code is to be replaced with `monetize` call once strict parsing is supported.

Fixes #589 