### PR TITLE
Temporary pin rails to < 5.2.4.1 on ruby < 2.3 to unblock Travis builds

### DIFF
--- a/gemfiles/mongoid6.gemfile
+++ b/gemfiles/mongoid6.gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'mongoid', '~> 6.0'
-gem 'rails',   '~> 5.1'
+rails_version = ['~> 5.1']
+rails_version << '< 5.2.4.1' if RUBY_VERSION < '2.3' # temporary fix until 5.2.4.2 is released
+gem 'rails', rails_version
 gem 'i18n',    '~> 0.7'
 
 platforms :jruby do

--- a/gemfiles/mongoid7.gemfile
+++ b/gemfiles/mongoid7.gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'mongoid', '~> 7.0'
-gem 'rails',   '~> 5.1'
+rails_version = ['~> 5.1']
+rails_version << '< 5.2.4.1' if RUBY_VERSION < '2.3' # temporary fix until 5.2.4.2 is released
+gem 'rails', rails_version
 gem 'i18n',    '~> 0.7'
 
 platforms :jruby do

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 5.0'
+rails_version = ['~> 5.1']
+rails_version << '< 5.2.4.1' if RUBY_VERSION < '2.3' # temporary fix until 5.2.4.2 is released
+gem 'rails', rails_version
 gem 'i18n',  '< 1.5'
 
 platforms :jruby do


### PR DESCRIPTION
The fix for the issue has been already merged in `5.2` branch, but still hasn't been released