### PR TITLE
Fix deprecation warnings in ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ cache: bundler
 services: mongodb
 rvm:
   - 2.3.8
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
   - 2.7.1
   - ruby-head
   #  TODO: investigate failure
@@ -39,33 +39,33 @@ matrix:
     - rvm: 2.3.8
       gemfile: gemfiles/rails6.gemfile
 
-    - rvm: 2.4.9
+    - rvm: 2.4.10
       gemfile: gemfiles/rails6.gemfile
-    - rvm: 2.4.9
+    - rvm: 2.4.10
       gemfile: gemfiles/rails3.gemfile
-    - rvm: 2.4.9
+    - rvm: 2.4.10
       gemfile: gemfiles/rails4.gemfile
-    - rvm: 2.4.9
+    - rvm: 2.4.10
       gemfile: gemfiles/mongoid2.gemfile
-    - rvm: 2.4.9
+    - rvm: 2.4.10
       gemfile: gemfiles/mongoid3.gemfile
 
-    - rvm: 2.5.7
+    - rvm: 2.5.8
       gemfile: gemfiles/rails3.gemfile
-    - rvm: 2.5.7
+    - rvm: 2.5.8
       gemfile: gemfiles/rails4.gemfile
-    - rvm: 2.5.7
+    - rvm: 2.5.8
       gemfile: gemfiles/mongoid2.gemfile
-    - rvm: 2.5.7
+    - rvm: 2.5.8
       gemfile: gemfiles/mongoid3.gemfile
 
-    - rvm: 2.6.5
+    - rvm: 2.6.6
       gemfile: gemfiles/rails3.gemfile
-    - rvm: 2.6.5
+    - rvm: 2.6.6
       gemfile: gemfiles/rails4.gemfile
-    - rvm: 2.6.5
+    - rvm: 2.6.6
       gemfile: gemfiles/mongoid2.gemfile
-    - rvm: 2.6.5
+    - rvm: 2.6.6
       gemfile: gemfiles/mongoid3.gemfile
 
     - rvm: 2.7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 sudo: false
 dist: trusty
 before_install:
-  # Rubygems > 3.0.0 no longer supported rubies < 2.3
-  - gem install "rubygems-update:<3.0.0" --no-document && update_rubygems
-  # Bundler 2.0 is not supported by Rails < 5
-  - gem list -i bundler -v '>= 2.0.0' && rvm @global do gem uninstall bundler -x || true
-  - gem install bundler -v '~> 1.17'
+  - gem install bundler --version '~> 1.17'
 before_script:
   - "bundle exec rake prepare_test_env"
 script: "bundle exec rspec"
@@ -13,7 +9,6 @@ language: ruby
 cache: bundler
 services: mongodb
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.10
   - 2.2.10
@@ -21,6 +16,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.1
   - ruby-head
   #  TODO: investigate failure
   #  This is an arbitrary failure on travis
@@ -43,17 +39,6 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   exclude:
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails6.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails5.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/mongoid5.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/mongoid6.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/mongoid7.gemfile
-
     - rvm: 2.0.0
       gemfile: gemfiles/rails6.gemfile
     - rvm: 2.0.0
@@ -111,14 +96,39 @@ matrix:
     - rvm: 2.6.5
       gemfile: gemfiles/mongoid3.gemfile
 
+    - rvm: 2.7.1
+      gemfile: gemfiles/rails3.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/rails4.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/rails5.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/mongoid2.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/mongoid3.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/mongoid4.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/mongoid5.gemfile
+    - rvm: 2.7.1
+      gemfile: gemfiles/mongoid6.gemfile
+
     - rvm: ruby-head
       gemfile: gemfiles/rails3.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails4.gemfile
     - rvm: ruby-head
+      gemfile: gemfiles/rails5.gemfile
+    - rvm: ruby-head
       gemfile: gemfiles/mongoid2.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/mongoid3.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/mongoid4.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/mongoid5.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/mongoid6.gemfile
 
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ language: ruby
 cache: bundler
 services: mongodb
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.10
   - 2.3.8
   - 2.4.9
   - 2.5.7
@@ -39,31 +36,6 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   exclude:
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails6.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails5.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/mongoid5.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/mongoid6.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/mongoid7.gemfile
-
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails6.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails5.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/mongoid5.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/mongoid6.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/mongoid7.gemfile
-
-    - rvm: 2.2.10
-      gemfile: gemfiles/rails6.gemfile
-
     - rvm: 2.3.8
       gemfile: gemfiles/rails6.gemfile
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require 'rubygems'
 require 'bundler'
 require 'bundler/gem_tasks'
 

--- a/gemfiles/mongoid6.gemfile
+++ b/gemfiles/mongoid6.gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'mongoid', '~> 6.0'
-rails_version = ['~> 5.1']
-gem 'rails', rails_version
+gem 'rails',   '~> 5.1'
 gem 'i18n',    '~> 0.7'
 
 platforms :jruby do

--- a/gemfiles/mongoid6.gemfile
+++ b/gemfiles/mongoid6.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'mongoid', '~> 6.0'
 rails_version = ['~> 5.1']
-rails_version << '< 5.2.4.1' if RUBY_VERSION < '2.3' # temporary fix until 5.2.4.2 is released
 gem 'rails', rails_version
 gem 'i18n',    '~> 0.7'
 

--- a/gemfiles/mongoid7.gemfile
+++ b/gemfiles/mongoid7.gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'mongoid', '~> 7.0'
-rails_version = ['~> 5.1']
-gem 'rails', rails_version
+gem 'rails',   RUBY_VERSION >= '2.5' ? '~> 6.0' : '~> 5.1'
 gem 'i18n',    '~> 0.7'
 
 platforms :jruby do
@@ -12,7 +11,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.3.6"
+  gem "sqlite3", "~> 1.4.2"
 end
 
 gemspec path: '../'

--- a/gemfiles/mongoid7.gemfile
+++ b/gemfiles/mongoid7.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'mongoid', '~> 7.0'
 rails_version = ['~> 5.1']
-rails_version << '< 5.2.4.1' if RUBY_VERSION < '2.3' # temporary fix until 5.2.4.2 is released
 gem 'rails', rails_version
 gem 'i18n',    '~> 0.7'
 

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 rails_version = ['~> 5.1']
-rails_version << '< 5.2.4.1' if RUBY_VERSION < '2.3' # temporary fix until 5.2.4.2 is released
 gem 'rails', rails_version
 gem 'i18n',  '< 1.5'
 

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-rails_version = ['~> 5.1']
-gem 'rails', rails_version
+gem 'rails', '~> 5.1'
 gem 'i18n',  '< 1.5'
 
 platforms :jruby do

--- a/lib/money-rails/active_record/migration_extensions/schema_statements_pg_rails4.rb
+++ b/lib/money-rails/active_record/migration_extensions/schema_statements_pg_rails4.rb
@@ -11,7 +11,7 @@ module MoneyRails
 
         def remove_monetize(table_name, accessor, options = {})
           [:amount, :currency].each do |attribute|
-            column_present, table_name, column_name, type, = OptionsExtractor.extract attribute, table_name, accessor, options
+            column_present, table_name, column_name, type = OptionsExtractor.extract attribute, table_name, accessor, options
             remove_column table_name, column_name, type if column_present
           end
         end

--- a/lib/money-rails/active_record/migration_extensions/schema_statements_pg_rails4.rb
+++ b/lib/money-rails/active_record/migration_extensions/schema_statements_pg_rails4.rb
@@ -2,16 +2,16 @@ module MoneyRails
   module ActiveRecord
     module MigrationExtensions
       module SchemaStatements
-        def add_monetize(table_name, accessor, options={})
+        def add_monetize(table_name, accessor, options = {})
           [:amount, :currency].each do |attribute|
-            column_present, *opts = OptionsExtractor.extract attribute, table_name, accessor, options
-            add_column(*opts) if column_present
+            column_present, table_name, column_name, column_type, opts = OptionsExtractor.extract attribute, table_name, accessor, options
+            add_column(table_name, column_name, column_type, **opts) if column_present
           end
         end
 
-        def remove_monetize(table_name, accessor, options={})
+        def remove_monetize(table_name, accessor, options = {})
           [:amount, :currency].each do |attribute|
-            column_present, table_name, column_name, type, _ =  OptionsExtractor.extract attribute, table_name, accessor, options
+            column_present, table_name, column_name, type, = OptionsExtractor.extract attribute, table_name, accessor, options
             remove_column table_name, column_name, type if column_present
           end
         end

--- a/lib/money-rails/active_record/migration_extensions/table_pg_rails4.rb
+++ b/lib/money-rails/active_record/migration_extensions/table_pg_rails4.rb
@@ -11,7 +11,7 @@ module MoneyRails
 
         def remove_monetize(accessor, options = {})
           [:amount, :currency].each do |attribute|
-            column_present, _, column_name, = OptionsExtractor.extract attribute, :no_table, accessor, options
+            column_present, _, column_name = OptionsExtractor.extract attribute, :no_table, accessor, options
             remove column_name if column_present
           end
         end

--- a/lib/money-rails/active_record/migration_extensions/table_pg_rails4.rb
+++ b/lib/money-rails/active_record/migration_extensions/table_pg_rails4.rb
@@ -2,16 +2,16 @@ module MoneyRails
   module ActiveRecord
     module MigrationExtensions
       module Table
-        def monetize(accessor, options={})
+        def monetize(accessor, options = {})
           [:amount, :currency].each do |attribute|
-            column_present, _, *opts = OptionsExtractor.extract attribute, :no_table, accessor, options
-            column(*opts) if column_present
+            column_present, _, column_name, column_type, opts = OptionsExtractor.extract attribute, :no_table, accessor, options
+            column(column_name, column_type, **opts) if column_present
           end
         end
 
-        def remove_monetize(accessor, options={})
+        def remove_monetize(accessor, options = {})
           [:amount, :currency].each do |attribute|
-            column_present, _, column_name, _, _ =  OptionsExtractor.extract attribute, :no_table, accessor, options
+            column_present, _, column_name, = OptionsExtractor.extract attribute, :no_table, accessor, options
             remove column_name if column_present
           end
         end

--- a/lib/money-rails/version.rb
+++ b/lib/money-rails/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MoneyRails
-  VERSION = '1.13.3'
+  VERSION = '2.0.0'
 end

--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.description   = "This library provides integration of RubyMoney - Money gem with Rails"
   s.summary       = "Money gem integration with Rails"
   s.homepage      = "https://github.com/RubyMoney/money-rails"
+  s.required_ruby_version = Gem::Requirement.new('>= 2.0.0')
 
   s.files         =  Dir.glob("{lib,spec,config}/**/*")
   s.files         += %w(CHANGELOG.md LICENSE README.md)
@@ -30,7 +31,6 @@ Gem::Specification.new do |s|
   s.add_dependency "monetize",      "~> 1.9.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "railties",      ">= 3.0"
-  s.add_dependency "mime-types",    "< 3" if RUBY_VERSION < '2.0' # mime-types > 3 depends on mime-types-data, which doesn't support ruby 1.9
 
   s.add_development_dependency "rails",       ">= 3.0"
   s.add_development_dependency "rspec-rails", "~> 3.0"

--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description   = "This library provides integration of RubyMoney - Money gem with Rails"
   s.summary       = "Money gem integration with Rails"
   s.homepage      = "https://github.com/RubyMoney/money-rails"
-  s.required_ruby_version = Gem::Requirement.new('>= 2.0.0')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
 
   s.files         =  Dir.glob("{lib,spec,config}/**/*")
   s.files         += %w(CHANGELOG.md LICENSE README.md)
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails",       ">= 3.0"
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency 'database_cleaner', '~> 1.6.1'
-  s.add_development_dependency 'test-unit', '~> 3.0' if RUBY_VERSION >= '2.2'
+  s.add_development_dependency 'test-unit', '~> 3.0'
 
   if s.respond_to?(:metadata)
     s.metadata['changelog_uri'] = 'https://github.com/RubyMoney/money-rails/blob/master/CHANGELOG.md'

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 # The default gemfile is rails4
 gemfile = File.expand_path('../../../../gemfiles/rails4.gemfile', __FILE__)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'rspec/rails'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 # Silence warnings
+Money.locale_backend = :i18n
 if Money.respond_to?(:silence_core_extensions_deprecations=)
   Money.silence_core_extensions_deprecations = true
 end


### PR DESCRIPTION
Fixes #598

Ruby 2.7 requires the use of the double splat operator `**`, unfortunately this was not added until v2.0.0. That being said I also removed support for ruby 1.9.3 (its been EOL for 5 years, so I think it's about time).

Edit: also drop ruby v2.0, v2.1 & v2.2.