### PR TITLE
Pin connection_pool version for old ruby specs

### DIFF
--- a/gemfiles/mongoid4.gemfile
+++ b/gemfiles/mongoid4.gemfile
@@ -4,6 +4,10 @@ gem 'mongoid', '~> 4.0'
 gem 'rails',   '~> 4.2'
 gem 'i18n',    '~> 0.7'
 
+if RUBY_VERSION <= '2.0.0'
+  gem 'connection_pool', '2.2.2'
+end
+
 platforms :jruby do
   gem "activerecord-jdbc-adapter"
   gem "activerecord-jdbcsqlite3-adapter"


### PR DESCRIPTION
The builds are failing due to connection_pool incompatibility with old rubies (<= 2.0.0). This should stop the bleeding, but we should also drop support for old rubies in the next major release