### PR TITLE
Use connection_db_config if it exists

### DIFF
--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -18,7 +18,13 @@ module MoneyRails
                                     else
                                       false
                                     end
-            current_adapter = ::ActiveRecord::Base.connection_config[:adapter]
+
+            current_adapter = if ::ActiveRecord::Base.respond_to?(:connection_db_config)
+                                ::ActiveRecord::Base.connection_db_config.configuration_hash[:adapter]
+                              else
+                                ::ActiveRecord::Base.connection_config[:adapter]
+                              end
+
             postgresql_with_money = rails42 && PG_ADAPTERS.include?(current_adapter)
           end
         end


### PR DESCRIPTION
With the current version of Rails 6.1, `money-rails` causes this warning when running tests

```
DEPRECATION WARNING: connection_config is deprecated and will be removed from Rails 6.2 (Use connection_db_config instead) (called from block in init at /Users/tomgilligan/.asdf/installs/ruby/2.6.1/lib/ruby/gems/2.6.0/gems/money-rails-1.13.3/lib/money-rails/hooks.rb:21)
```

This PR fixes this warning by doing things the new way if possible.