### PR TITLE
Support validation when `monetized` is used

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -30,7 +30,7 @@ module MoneyRails
         return if options[:allow_nil] && raw_value.nil?
 
         # Set this before we modify raw_value below.
-        stringy = raw_value.present? && !raw_value.is_a?(Numeric) && !raw_value.is_a?(Money)
+        stringy = raw_value.present? && !raw_value.is_a?(Numeric) && !raw_value.is_a?(Money) && !raw_value.is_a?(Hash)
 
         if stringy
           # TODO: This is supporting legacy behaviour where a symbol can come from a i18n locale,
@@ -39,6 +39,11 @@ module MoneyRails
 
           # remove currency symbol
           raw_value = raw_value.to_s.gsub(symbol, "")
+        end
+
+        if raw_value.present? && raw_value.is_a?(Hash)
+          
+          raw_value = raw_value.to_money(currency)
         end
 
         # Cache abs_raw_value before normalizing because it's used in

--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -42,7 +42,6 @@ module MoneyRails
         end
 
         if raw_value.present? && raw_value.is_a?(Hash)
-          
           raw_value = raw_value.to_money(currency)
         end
 

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -400,6 +400,35 @@ if defined? ActiveRecord
         expect(product.errors[:price].first).to match(/is not a number/)
       end
 
+      it "passes validation when Money is given" do
+        product = Product.create(price_in_a_range: Money.new(5000, 'usd'))
+        expect(product.errors[:price_in_a_range].size).to eq(0)
+      end
+
+      it "passes validation when Hash which has cents and currency is given" do
+        product = Product.create(price_in_a_range: { cents: 5000, currency:'usd'})
+        expect(product.price_in_a_range).to eq(Money.new(5000, 'usd'))
+        expect(product.errors[:price_in_a_range].size).to eq(0)
+      end
+
+      it "passes validation when Hash without currency is given" do
+        product = Product.create(price_in_a_range: { cents: 5000 })
+        expect(product.price_in_a_range).to eq(Money.new(5000, 'usd'))
+        expect(product.errors[:price_in_a_range].size).to eq(0)
+      end
+
+      it "fails validation when Hash without cents is given because the default value is too small" do
+        product = Product.create(price_in_a_range: {something_other_key: 3338})
+        expect(product.errors[:price_in_a_range].size).to eq(1)
+        expect(product.errors[:price_in_a_range].first).to match(/greater than zero/)
+      end
+
+      it "fails validation when Hash without cents is given because the default value is too small2" do
+        product = Product.create(price_in_a_range: nil)
+        expect(product.errors[:price_in_a_range].size).to eq(0)
+        expect(product.errors[:price_in_a_range].first).to match(/greater than zero/)
+      end
+
       it "passes validation when amount contains spaces (999 999.99)" do
         product.price = "999 999.99"
         expect(product).to be_valid


### PR DESCRIPTION
Supports validation when a hash is provided to a `monetized` attribute.

Example:

Given Product:

```ruby
class Product
  monetize :price_in_a_range_cents, allow_nil: true,
                                    subunit_numericality: {
                                      greater_than: 0,
                                      less_than_or_equal_to: 10000
                                    },
                                    numericality: {
                                      greater_than: 0,
                                      less_than_or_equal_to: 100,
                                      message: "must be greater than zero and less than $100"
                                    }
end
```

the following code passes validation:

```ruby
Product.create(price_in_a_range:{amount: 4, currency: 'usd'})
Product.create(price_in_a_range:{cents: 4})
Product.create(price_in_a_range:{}) # treats it as if `nil` was passed
```
While the following would not pass:

```ruby
Product.create(price_in_a_range:{currency: 'usd'}) # treat it as if `0` was passed to cents
Product.create(price_in_range:{some_other_key: 289}) # treat it as if `0` was passed to cents
```

Closes #627



