### PR TITLE
Update changelog version to match the gem version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.14.1
+## 1.15.0
 
 - Fix invalid_currency error definition
 - Add Russian translation for errors


### PR DESCRIPTION
As described in [Gem version module](https://github.com/RubyMoney/money-rails/blob/main/lib/money-rails/version.rb)

The Changelog version should be 1.15.0