### PR TITLE
Add ActiveJob serializer for Money objects

### DIFF
--- a/lib/money-rails/active_job/money_serializer.rb
+++ b/lib/money-rails/active_job/money_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module MoneyRails
+  module ActiveJob
+    class MoneySerializer < ::ActiveJob::Serializers::ObjectSerializer
+      def serialize?(argument)
+        argument.is_a?(Money)
+      end
+
+      def serialize(money)
+        super("cents" => money.cents, "currency" => money.currency.to_s)
+      end
+
+      def deserialize(hash)
+        Money.new(hash["cents"], hash["currency"])
+      end
+    end
+  end
+end

--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -56,6 +56,17 @@ module MoneyRails
         require 'money-rails/helpers/action_view_extension'
         ::ActionView::Base.send :include, MoneyRails::ActionViewExtension
       end
+
+      # For ActiveSupport
+      ActiveSupport.on_load(:active_job) do |v|
+        if defined?(::ActiveJob::Serializers)
+          require 'money-rails/active_job/money_serializer'
+          Rails.application.config.active_job.tap do |config|
+            config.custom_serializers ||= []
+            config.custom_serializers << MoneyRails::ActiveJob::MoneySerializer
+          end
+        end
+      end
     end
   end
 end

--- a/spec/active_job/money_serializer_spec.rb
+++ b/spec/active_job/money_serializer_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+if defined?(::ActiveJob::Serializers)
+  describe MoneyRails::ActiveJob::MoneySerializer do
+    let(:money) { Money.new(1_00, "EUR") }
+    let(:serialized_money) do
+      {
+        "_aj_serialized" => "MoneyRails::ActiveJob::MoneySerializer",
+        "cents" => 1_00,
+        "currency" => "EUR",
+      }
+    end
+
+    describe "#serialize?" do
+      it { expect(described_class.serialize?(money)).to be_truthy }
+      it { expect(described_class.serialize?(1_00)).not_to be_truthy }
+    end
+
+    describe "#serialize" do
+      it { expect(described_class.serialize(money)).to eq(serialized_money) }
+    end
+
+    describe "#deserialize" do
+      it { expect(described_class.deserialize(serialized_money)).to eq(money) }
+    end
+  end
+end


### PR DESCRIPTION
This change adds a serializer so that ActiveJob can enqueue jobs with Money arguments out of the box.

I’ve been using the same serializer in a production app for a while, and think this would help users not have to create their own serializer.

See also: [Documentation for Active Job serializers](https://guides.rubyonrails.org/active_job_basics.html#serializers).

(Follow-up to #658)
