### PR TITLE
Fix currency change during init

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -148,6 +148,13 @@ module MoneyRails
             after_save do
               instance_variable_set "@#{name}_money_before_type_cast", nil
             end
+
+            # This hack ensures that if the currency exponent changed during
+            # initialization the subunit is updated correctly.
+            # See https://github.com/RubyMoney/money-rails/issues/645
+            after_initialize do
+              amount = public_send(name)
+            end
           end
         end
 

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -56,4 +56,7 @@ class Product < ActiveRecord::Base
 
   # Using postfix to determine currency column (reduced_price_currency)
   monetize :reduced_price_cents, allow_nil: true
+
+  monetize :unvalidated_sale_price_amount, as: :unvalidated_sale_price,
+    with_model_currency: :sale_price_currency_code, disable_validation: true
 end

--- a/spec/dummy/db/migrate/20201013143420_add_unvalidated_sale_price_amount_to_products.rb
+++ b/spec/dummy/db/migrate/20201013143420_add_unvalidated_sale_price_amount_to_products.rb
@@ -1,0 +1,6 @@
+class AddUnvalidatedSalePriceAmountToProducts < (Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration)
+  def change
+    add_column :products, :unvalidated_sale_price_amount, :integer,
+      default: 0, null: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2015_10_26_220420) do
+ActiveRecord::Schema.define(version: 2020_10_13_143420) do
 
   create_table "dummy_products", force: :cascade do |t|
     t.string "currency"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2015_10_26_220420) do
     t.integer "special_price_cents"
     t.integer "lambda_price_cents"
     t.string "skip_validation_price_cents"
+    t.integer "unvalidated_sale_price_amount", default: 0, null: false
   end
 
   create_table "services", force: :cascade do |t|


### PR DESCRIPTION
Partially fixes #645. This works for construction but not for every change of the instance variable. I'd love more feedback on how to approach that.