### PR TITLE
Allow monetizing methods with kwargs

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -118,8 +118,8 @@ module MoneyRails
 
 
             # Getter for monetized attribute
-            define_method name do |*args|
-              read_monetized name, subunit_name, options, *args
+            define_method name do |*args, **kwargs|
+              read_monetized name, subunit_name, options, *args, **kwargs
             end
 
             # Setter for monetized attribute
@@ -178,9 +178,9 @@ module MoneyRails
         end
       end
 
-      def read_monetized(name, subunit_name, options = {}, *args)
+      def read_monetized(name, subunit_name, options = {}, *args, **kwargs)
         # Get the cents
-        amount = public_send(subunit_name, *args)
+        amount = public_send(subunit_name, *args, **kwargs)
 
         return if amount.nil? && options[:allow_nil]
         # Get the currency object

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -725,6 +725,10 @@ if defined? ActiveRecord
           expect(transaction.total).to eq(Money.new(3000, :usd))
         end
 
+        it "constructs the money object from the mapped method value with arguments" do
+          expect(transaction.total(1, bar: 2)).to eq(Money.new(3003, :usd))
+        end
+
         it "allows currency column postfix to be blank" do
           allow(MoneyRails::Configuration).to receive(:currency_column) { { postfix: nil, column_name: 'currency' } }
           expect(dummy_product_with_nil_currency.price.currency).to eq(Money::Currency.find(:gbp))

--- a/spec/dummy/app/models/transaction.rb
+++ b/spec/dummy/app/models/transaction.rb
@@ -7,7 +7,7 @@ class Transaction < ActiveRecord::Base
 
   monetize :optional_amount_cents, with_model_currency: :currency, allow_nil: true
 
-  def total_cents
-    return amount_cents + tax_cents
+  def total_cents(foo = 0, bar: 0)
+    return amount_cents + tax_cents + foo + bar
   end
 end


### PR DESCRIPTION
`monetize` works for methods with positional arguments, i.e. `def foo_cents(bar)`.

Add support for keyword arguments, i.e. `def foo_cents(bar:)`.