### PR TITLE
Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RubyMoney - Money-Rails
 
 [![Gem Version](https://badge.fury.io/rb/money-rails.svg)](http://badge.fury.io/rb/money-rails)
-[![Build Status](https://secure.travis-ci.org/RubyMoney/money-rails.svg?branch=master)](http://travis-ci.org/RubyMoney/money-rails)
+[![Ruby](https://github.com/RubyMoney/money-rails/actions/workflows/ruby.yml/badge.svg)](https://github.com/RubyMoney/money-rails/actions/workflows/ruby.yml)
 [![License](http://img.shields.io/:license-mit-green.svg?style=flat)](http://opensource.org/licenses/MIT)
 
 ## Introduction


### PR DESCRIPTION
The old badge was pointing to Travis.

This commits uses the GitHub generated markdown code for ruby workflow

[ci skip]

### Before
<img width="904" alt="image" src="https://github.com/RubyMoney/money-rails/assets/556268/473a26a8-bc59-476a-a459-99719be7f97b">


### After
<img width="902" alt="image" src="https://github.com/RubyMoney/money-rails/assets/556268/d8ff7f94-6411-4903-95eb-5c76818956e6">
