### PR TITLE
Fix monetized_attributes class discrepancy

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -10,7 +10,7 @@ module MoneyRails
 
       module ClassMethods
         def monetized_attributes
-          monetized_attributes = @monetized_attributes || {}
+          monetized_attributes = @monetized_attributes || {}.with_indifferent_access
 
           if superclass.respond_to?(:monetized_attributes)
             monetized_attributes.merge(superclass.monetized_attributes)


### PR DESCRIPTION
Suppose we have a model

```ruby
class Investment < ActiveRecord::Base
  monetize :value
  monetize :discounted_value
end
```

and a subclass

```ruby
class BadInvestment < Investment
end
```

When we check the monetized_attributes of both the `Product` and `SpecialProduct` we get seemingly the same result:

```ruby
Investment.monetized_attributes
# => {
  'value' => 'value_cents',
  'discounted_value' => 'discounted_value_cents',
}

BadInvestment.monetized_attributes
# => {
  'value' => 'value_cents',
  'discounted_value' => 'discounted_value_cents',
}
```

...but when we check the class of the `monetized_attributes` we can see that one is a `ActiveSupport::HashWithIndifferentAccess` while the other is a `Hash`.

```ruby
Investment.monetized_attributes.class
# => ActiveSupport::HashWithIndifferentAccess

BadInvestment.monetized_attributes
# => Hash
```

This pull request fixes the discrepancy, ensuring both are a `ActiveSupport::HashWithIndifferentAccess`.