### PR TITLE
Fix money_only_cents for negative money

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Allow monetizing methods with kwargs
+- Fix money_only_cents for negative money
 
 ## 1.15.0
 

--- a/lib/money-rails/helpers/action_view_extension.rb
+++ b/lib/money-rails/helpers/action_view_extension.rb
@@ -53,7 +53,7 @@ module MoneyRails
 
       value = value.to_money
 
-      format "%0#{value.currency.exponent}d", (value % value.currency.subunit_to_unit).cents
+      format "%0#{value.currency.exponent}d", (value.abs % value.currency.subunit_to_unit).cents
     end
   end
 end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -105,6 +105,11 @@ describe 'MoneyRails::ActionViewExtension', type: :helper do
       let(:monetizable_object){ false }
       it { is_expected.to eq "00" }
     end
+
+    context 'with a negative monetizable object' do
+      let(:monetizable_object){ Money.new(-125) }
+      it { is_expected.to eq "25" }
+    end
   end
 
   context 'respects MoneyRails::Configuration settings' do

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -107,7 +107,7 @@ describe 'MoneyRails::ActionViewExtension', type: :helper do
     end
 
     context 'with a negative monetizable object' do
-      let(:monetizable_object){ Money.new(-125) }
+      let(:monetizable_object){ Money.new(-1_25) }
       it { is_expected.to eq "25" }
     end
   end


### PR DESCRIPTION
**What/Why**
When given negative money, `money_only_cents` view helper does not return the expected subunit value due to how modulo handles negative numbers.
For example: -125 % 100 = 75

**What was done**
To fix, I've updated the calculation to use the absolute value and added a new spec to cover the use case. 