### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/money-rails.gemspec
+++ b/money-rails.gemspec
@@ -42,5 +42,6 @@ Gem::Specification.new do |s|
     s.metadata['changelog_uri'] = 'https://github.com/RubyMoney/money-rails/blob/master/CHANGELOG.md'
     s.metadata['source_code_uri'] = 'https://github.com/RubyMoney/money-rails/'
     s.metadata['bug_tracker_uri'] = 'https://github.com/RubyMoney/money-rails/issues'
+    s.metadata['rubygems_mfa_required'] = 'true'
   end
 end


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/