### PR TITLE
Add Portuguese translation for errors

### DIFF
--- a/config/locales/money.pt.yml
+++ b/config/locales/money.pt.yml
@@ -1,0 +1,4 @@
+pt:
+  errors:
+    messages:
+      invalid_currency: tem um formato inválido (deve ser '100', '5%{decimal}24', ou '123%{thousands}456%{decimal}78'). Recebido %{currency}


### PR DESCRIPTION
Adds a translation file for Portuguese with the error message for an invalid currency.