### PR TITLE
Define methods on dynamic module

### DIFF
--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -30,6 +30,23 @@ if defined? ActiveRecord
 
       context ".monetized_attributes" do
 
+        it "allows adds methods to the inheritance chain" do
+          class MyProduct < ActiveRecord::Base
+            self.table_name = :products
+            monetize :price_cents
+            attr_reader :side_effect
+
+            def price=(value)
+              @side_effect = true
+              super
+            end
+          end
+
+          p = MyProduct.new(price: 10)
+          expect(p.price).to eq Money.new(10_00)
+          expect(p.side_effect).to be_truthy
+        end
+
         class InheritedMonetizeProduct < Product
           monetize :special_price_cents
         end


### PR DESCRIPTION
Currently you cannot override the generated methods and access super ie:

```ruby
class Transaction < ApplicationRecord
  monetize :price_cents

  def price=(value)
    # stuff
   super # NoMethodError
  end
end
```

This happens because the method is defined on the class directly so their is no super method to call. A solution today is to create an alias (`alias :old_price= :price=`) before overriding the method as is recommending in issue #507.

Instead, a new module can be created, included into the class, and the methods defined on it allowing `super` to work as expected.