### PR TITLE
Improve job name for clarity in workflow runs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: Ruby
+name: CI
 
 on:
   push:
@@ -22,6 +22,8 @@ jobs:
         ruby-version: ['3.1', '3.2', '3.3', '3.4']
         mongodb-version: ['4.4']
         sqlite-version: ['3.0']
+
+    name: Test (Ruby ${{ matrix.ruby-version }}, MongoDB ${{ matrix.mongodb-version }}, SQLite ${{ matrix.sqlite-version }})
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
# ⚠️ CI-settings breaking change. Settings should be changed to require status to pass with the new name

-----

Previously, the job name in the workflow matrix only displayed version numbers, resulting in ambiguous labels like

```
Ruby / test (3.1, 4.4, 3.0)
```

This commit updates the job name to explicitly include the technology names alongside their versions:

```
CI / Test (Ruby 3.1, MongoDB 4.4, SQLite 3.0)
```

This change makes it immediately clear which version number corresponds to which technology, improving readability and reducing confusion when reviewing workflow results.

---

<img width="455" height="294" alt="image" src="https://github.com/user-attachments/assets/3df98a38-bc3f-4c4e-8a09-606b2a019fea" />
