### PR TITLE
Remove unneeded check on `ActiveModel#attribute_aliases`

### DIFF
--- a/lib/money-rails/active_record/monetizable.rb
+++ b/lib/money-rails/active_record/monetizable.rb
@@ -271,12 +271,9 @@ module MoneyRails
           # We haven't defined our own subunit writer, so we can invoke
           # the regular writer, which works with store_accessors
           public_send("#{subunit_name}=", money.try(:cents))
-        elsif self.class.respond_to?(:attribute_aliases) &&
-              self.class.attribute_aliases.key?(subunit_name)
+        elsif self.class.attribute_aliases.key?(subunit_name)
           # If the attribute is aliased, make sure we write to the original
           # attribute name or an error will be raised.
-          # (Note: 'attribute_aliases' doesn't exist in Rails 3.x, so we
-          # can't tell if the attribute was aliased.)
           original_name = self.class.attribute_aliases[subunit_name.to_s]
           write_attribute(original_name, money.try(:cents))
         else


### PR DESCRIPTION
As far as I can tell, `ActiveModel#attribute_aliases` has been in Rails since at least version 6 so there shouldn't be a reason to check whether the method is on the record class. The removed comment implies it was added in Rails 4 but who knows? In regards to the current supported versions: here's the [file](https://github.com/rails/rails/blob/f4321f78fe567fd29dd0a0fb5cb17af68efd36bb/activemodel/lib/active_model/attribute_methods.rb) included in on Rails 7 and here's the [file](https://github.com/rails/rails/blob/64b90c735614681fcf6e2e7f0022c8a9d2f8554f/activemodel/lib/active_model/attribute_methods.rb) for Rails 8.

This removes the unnecessary check.