### PR TITLE
Refactor: Move validation and normalization logic into Details class

### DIFF
--- a/lib/money-rails/active_model/validator.rb
+++ b/lib/money-rails/active_model/validator.rb
@@ -11,6 +11,36 @@ module MoneyRails
         def decimal_pieces
           @decimal_pieces ||= abs_raw_value.split(decimal_mark)
         end
+
+        def too_many_decimal_points?
+          !decimal_pieces.length.between?(1, 2)
+        end
+
+        def thousand_separator_after_decimal_mark?
+          thousands_separator.present? &&
+            decimal_pieces.length == 2 &&
+            decimal_pieces[1].include?(thousands_separator)
+        end
+
+        def invalid_thousands_separation?
+          pieces_array = decimal_pieces[0].split(thousands_separator.presence)
+
+          return false if pieces_array.length <= 1
+          return true  if pieces_array[0].length > 3
+
+          pieces_array[1..].any? do |thousands_group|
+            thousands_group.length != 3
+          end
+        end
+
+        # Remove thousands separators, normalize decimal mark,
+        # remove whitespaces and _ (E.g. 99 999 999 or 12_300_200.20)
+        def normalize
+          raw_value.to_s
+                   .gsub(thousands_separator, "")
+                   .gsub(decimal_mark, ".")
+                   .gsub(/[\s_]/, "")
+        end
       end
 
       def validate_each(record, attr, _value)
@@ -46,17 +76,16 @@ module MoneyRails
         # Cache abs_raw_value before normalizing because it's used in
         # many places and relies on the original raw_value.
         details = generate_details(raw_value, currency)
-        normalized_raw_value = normalize(details)
+        normalized_raw_value = details.normalize
 
         super(record, attr, normalized_raw_value)
 
         return unless stringy
         return if record_already_has_error?(record, attr, normalized_raw_value)
 
-        add_error!(record, attr, details) if
-          value_has_too_many_decimal_points?(details) ||
-          thousand_separator_after_decimal_mark?(details) ||
-          invalid_thousands_separation?(details)
+        add_error!(record, attr, details) if details.too_many_decimal_points? ||
+                                             details.thousand_separator_after_decimal_mark? ||
+                                             details.invalid_thousands_separation?
       end
 
       private
@@ -91,38 +120,6 @@ module MoneyRails
           currency: details.abs_raw_value,
           attribute: attr_name,
         )
-      end
-
-      def value_has_too_many_decimal_points?(details)
-        ![1, 2].include?(details.decimal_pieces.length)
-      end
-
-      def thousand_separator_after_decimal_mark?(details)
-        details.thousands_separator.present? &&
-          details.decimal_pieces.length == 2 &&
-          details.decimal_pieces[1].include?(details.thousands_separator)
-      end
-
-      def invalid_thousands_separation?(details)
-        pieces_array = details.decimal_pieces[0].split(details.thousands_separator.presence)
-
-        return false if pieces_array.length <= 1
-        return true  if pieces_array[0].length > 3
-
-        pieces_array[1..].any? do |thousands_group|
-          thousands_group.length != 3
-        end
-      end
-
-      # Remove thousands separators, normalize decimal mark,
-      # remove whitespaces and _ (E.g. 99 999 999 or 12_300_200.20)
-      def normalize(details)
-        details
-          .raw_value
-          .to_s
-          .gsub(details.thousands_separator, "")
-          .gsub(details.decimal_mark, ".")
-          .gsub(/[\s_]/, "")
       end
 
       def lookup(key, currency)


### PR DESCRIPTION
Moved `normalize` and validation logic from the validator into the `Details` class.

Methods moved:
- `normalize`
- `value_has_too_many_decimal_points?` (renamed to `too_many_decimal_points?`)
- `thousand_separator_after_decimal_mark?`
- `invalid_thousands_separation?`