### PR TITLE
Fix MoneySerializer not registered on Rails 8.1.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `MoneyRails::ActiveJob::MoneySerializer` not being registered on Rails 8.1+ (#779)
+
 ## 3.0.0
 
 - **Breaking change**: Drop support for Rails < 7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix `MoneyRails::ActiveJob::MoneySerializer` not being registered on Rails 8.1+ (#779)
+- Fix `MoneyRails::ActiveJob::MoneySerializer` not being registered on Rails 8.1+, and on older versions without eager loading (#779)
 
 ## 3.0.0
 

--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -43,14 +43,20 @@ module MoneyRails
         ::ActionView::Base.include MoneyRails::ActionViewExtension
       end
 
-      # For ActiveSupport
-      ActiveSupport.on_load(:active_job) do
-        if defined?(::ActiveJob::Serializers)
-          require "money-rails/active_job/money_serializer"
-          Rails.application.config.active_job.tap do |config|
-            config.custom_serializers ||= []
-            config.custom_serializers << MoneyRails::ActiveJob::MoneySerializer
-          end
+      # For Active Job
+      #
+      # Registered during initialization rather than inside an
+      # `ActiveSupport.on_load(:active_job)` block so the serializer is present in
+      # `config.active_job.custom_serializers` before Rails consumes the list. Rails
+      # reads it at different points across versions (`after_initialize` on <= 8.0,
+      # `on_load(:active_job)` on 8.1.0/8.1.1, `on_load(:active_job_arguments)` on 8.1.2+),
+      # any of which an `:active_job` hook here could lose the race to. See issue #779 and
+      # rails/rails commits b7cd3018ef (8.1.0) and c0dc92e9e9 (8.1.2).
+      if defined?(::ActiveJob::Serializers)
+        require "money-rails/active_job/money_serializer"
+        Rails.application.config.active_job.tap do |config|
+          config.custom_serializers ||= []
+          config.custom_serializers << MoneyRails::ActiveJob::MoneySerializer
         end
       end
     end

--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -44,20 +44,9 @@ module MoneyRails
       end
 
       # For Active Job
-      #
-      # Registered during initialization rather than inside an
-      # `ActiveSupport.on_load(:active_job)` block so the serializer is present in
-      # `config.active_job.custom_serializers` before Rails consumes the list. Rails
-      # reads it at different points across versions (`after_initialize` on <= 8.0,
-      # `on_load(:active_job)` on 8.1.0/8.1.1, `on_load(:active_job_arguments)` on 8.1.2+),
-      # any of which an `:active_job` hook here could lose the race to. See issue #779 and
-      # rails/rails commits b7cd3018ef (8.1.0) and c0dc92e9e9 (8.1.2).
       if defined?(::ActiveJob::Serializers)
         require "money-rails/active_job/money_serializer"
-        Rails.application.config.active_job.tap do |config|
-          config.custom_serializers ||= []
-          config.custom_serializers << MoneyRails::ActiveJob::MoneySerializer
-        end
+        ::ActiveJob::Serializers.add_serializers(MoneyRails::ActiveJob::MoneySerializer)
       end
     end
   end

--- a/spec/active_job/money_serializer_spec.rb
+++ b/spec/active_job/money_serializer_spec.rb
@@ -25,5 +25,13 @@ if defined?(ActiveJob::Serializers)
     describe "#deserialize" do
       it { expect(described_class.deserialize(serialized_money)).to eq(money) }
     end
+
+    describe "Active Job registration" do
+      it "round-trips Money through Active Job argument serialization" do
+        serialized = ActiveJob::Arguments.serialize([money])
+
+        expect(ActiveJob::Arguments.deserialize(serialized)).to eq([money])
+      end
+    end
   end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -4,6 +4,14 @@ require File.expand_path("boot", __dir__)
 require "logger"
 
 require "active_record/railtie" unless ENV["BUNDLE_GEMFILE"]&.include?("mongoid")
+# The Mongoid gemfiles depend on Action Pack only, not the full rails gem, so the
+# activejob gem may be unavailable. Load it only when present (the serializer specs
+# are guarded by `defined?(ActiveJob::Serializers)`).
+begin
+  require "active_job/railtie"
+rescue LoadError
+  nil
+end
 require "action_controller/railtie"
 
 Bundler.require


### PR DESCRIPTION
Fixes https://github.com/RubyMoney/money-rails/issues/779

Hello @sunny and whoever is watching 👋🏻 Claude and I had a stab at the reported issue and this is what we've come up with!  

Seems that on Rails 8.1+, `MoneyRails::ActiveJob::MoneySerializer` is not registered with Active Job, so serializing a `Money` job argument fails.

### Root cause

money-rails registered its serializer by appending to `config.active_job.custom_serializers` *inside* an
`ActiveSupport.on_load(:active_job)` block. Rails reads that list at a version-dependent moment:

| Rails | Consumes `custom_serializers` via |
|-------|-----------------------------------|
| ≤ 8.0 | `config.after_initialize` |
| 8.1.0 / 8.1.1 ([rails/rails@b7cd3018ef](https://github.com/rails/rails/commit/b7cd3018ef)) | `on_load(:active_job)` |
| 8.1.2+ ([rails/rails@c0dc92e9e9](https://github.com/rails/rails/commit/c0dc92e9e9)) | `on_load(:active_job_arguments)` |


Rails <= 8.0 read `config.active_job.custom_serializers` in `after_initialize` (end of boot), so money-rails's appended serializer was always there in time.

8.1.0 ([b7cd3018ef](https://github.com/rails/rails/commit/b7cd3018ef)) moved that read into `on_load(:active_job)` — the **same hook money-rails uses**. Load-hook callbacks run in registration order, and Rails registers before money-rails (a gem). So Rails reads the list while it's still empty, then money-rails appends too late .

8.1.2 changed Rails' read to `on_load(:active_job_arguments)` but changing money-rails to use that hook doesn't help. First, it is not compatible with older Rails version and, second, the hook could potentially be called before the custom serializer is in the list.) would break on 7.0–8.1.1.

### Fix

Register the serializer during initialization instead of inside a load hook, so it is present `config.active_job.custom_serializers` before Rails reads the list regardless of how Rails consumes it.

I added a simple integration test that round-trips a `Money` through `ActiveJob::Arguments`

@jaredmoody would you mind checking if this fixes what you are seeing? thanks!