### PR TITLE
docs: add money-unirate-api bank backend to config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,9 @@ MoneyRails.configure do |config|
   #
   # Example:
   # config.default_bank = EuCentralBank.new
+  #
+  # Other bank implementations:
+  # config.default_bank = Money::Bank::UniRate.new           # https://github.com/UniRate-API/money-unirate-api
 
   # Add exchange rates to current money bank object.
   # (The conversion rate refers to one direction only)
@@ -494,7 +497,11 @@ end
 * `add_rate`: Provide custom exchange rate for currencies in one direction only! This
   rate is added to the attached bank object.
 * `default_bank`: The default bank object holding exchange rates etc.
-  (https://github.com/RubyMoney/money#currency-exchange)
+  (https://github.com/RubyMoney/money#currency-exchange).
+  Third-party banks include
+  [eu_central_bank](https://github.com/RubyMoney/eu_central_bank),
+  [google_currency](https://github.com/RubyMoney/google_currency), and
+  [money-unirate-api](https://github.com/UniRate-API/money-unirate-api).
 * `default_format`: Force `Money#format` to use these options for formatting.
 * `amount_column`: Provide values for the amount column (holding the fractional part of a money object).
 * `currency_column`: Provide default values or even disable (`present: false`) the currency column.

--- a/lib/generators/templates/money.rb
+++ b/lib/generators/templates/money.rb
@@ -9,6 +9,9 @@ MoneyRails.configure do |config|
   #
   # Example:
   # config.default_bank = EuCentralBank.new
+  #
+  # Other bank implementations:
+  # config.default_bank = Money::Bank::UniRate.new           # https://github.com/UniRate-API/money-unirate-api
 
   # Add exchange rates to current money bank object.
   # (The conversion rate refers to one direction only)


### PR DESCRIPTION
## Summary

Adds [`money-unirate-api`](https://github.com/UniRate-API/money-unirate-api) as a documented bank backend option in two places:

- **README.md** config example block: adds `Money::Bank::UniRate.new` as an alternative to `EuCentralBank.new`
- **Initializer template** (`lib/generators/templates/money.rb`): same addition, so `rails generate money_rails:initializer` shows users both options
- **Config parameter docs**: lists available third-party banks (`eu_central_bank`, `google_currency`, `money-unirate-api`) under the `default_bank` bullet

No code changes — docs only.

## Context

`money-unirate-api` is a `Money::Bank::VariableExchange` subclass that fetches live exchange rates from the [UniRate API](https://unirateapi.com). Published on [RubyGems](https://rubygems.org/gems/money-unirate-api); zero runtime deps beyond `money` (>= 6.13, < 7); 22 RSpec tests; CI matrix Ruby 3.0-3.4.

**Disclosure:** I maintain the UniRate API and the `money-unirate-api` gem.
