### PR TITLE
Fix/ci lint and jruby

### DIFF
--- a/Gemfile.default
+++ b/Gemfile.default
@@ -26,3 +26,8 @@ gem "rubocop-rspec_rails", require: false
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2")
   gem "erb", "6.0.0"
 end
+
+# rdoc >= 8 pulls in rbs, whose C extension fails to build on JRuby and breaks
+# `bundle install`. rdoc < 8 has no rbs dependency and still satisfies irb's
+# `rdoc >= 4.0.0` requirement, so pin it below 8 on JRuby only.
+gem "rdoc", "< 8", platforms: :jruby

--- a/Gemfile.default
+++ b/Gemfile.default
@@ -16,11 +16,11 @@ gem "pry"
 gem "rspec-rails", "~> 6"
 
 # Linting
-gem "rubocop", require: false
-gem "rubocop-performance", require: false
-gem "rubocop-rake", require: false
-gem "rubocop-rspec", require: false
-gem "rubocop-rspec_rails", require: false
+gem "rubocop", "~> 1.88.0", require: false
+gem "rubocop-performance", "~> 1.26.0", require: false
+gem "rubocop-rake", "~> 0.7.0", require: false
+gem "rubocop-rspec", "~> 3.10.0", require: false
+gem "rubocop-rspec_rails", "~> 2.32.0", require: false
 
 # Fix GitHub CI caching issue by forcing specific version
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2")

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -268,21 +268,21 @@ if defined? ActiveRecord
         product.price = "12.23.24"
         expect(product.save).to be_falsey
         expect(product.errors[:price].size).to eq(1)
-        expect(product.errors[:price].first).to match(/not a number/)
+        expect(product.errors[:price].first).to include("not a number")
       end
 
       it "fails validation with the proper error message if money value is nothing but periods" do
         product.price = "..."
         expect(product.save).to be_falsey
         expect(product.errors[:price].size).to eq(1)
-        expect(product.errors[:price].first).to match(/not a number/)
+        expect(product.errors[:price].first).to include("not a number")
       end
 
       it "fails validation with the proper error message if money value has invalid thousands part" do
         product.price = "12,23.24"
         expect(product.save).to be_falsey
         expect(product.errors[:price].size).to eq(1)
-        expect(product.errors[:price].first).to match(/has invalid format/)
+        expect(product.errors[:price].first).to include("has invalid format")
         expect(product.errors[:price].first).to match(/Got 12,23.24/)
       end
 
@@ -290,7 +290,7 @@ if defined? ActiveRecord
         product.price = "1.234,56"
         expect(product.save).to be_falsey
         expect(product.errors[:price].size).to eq(1)
-        expect(product.errors[:price].first).to match(/has invalid format/)
+        expect(product.errors[:price].first).to include("has invalid format")
         expect(product.errors[:price].first).to match(/Got 1.234,56/)
       end
 
@@ -322,17 +322,17 @@ if defined? ActiveRecord
         product.price_in_a_range = "-12"
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range].size).to eq(1)
-        expect(product.errors[:price_in_a_range].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:price_in_a_range].first).to include("must be greater than zero and less than $100")
 
         product.price_in_a_range = Money.new(-1200, "USD")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range].size).to eq(1)
-        expect(product.errors[:price_in_a_range].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:price_in_a_range].first).to include("must be greater than zero and less than $100")
 
         product.price_in_a_range = "0"
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range].size).to eq(1)
-        expect(product.errors[:price_in_a_range].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:price_in_a_range].first).to include("must be greater than zero and less than $100")
 
         product.price_in_a_range = "12"
         expect(product.valid?).to be_truthy
@@ -343,12 +343,12 @@ if defined? ActiveRecord
         product.price_in_a_range = "101"
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range].size).to eq(1)
-        expect(product.errors[:price_in_a_range].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:price_in_a_range].first).to include("must be greater than zero and less than $100")
 
         product.price_in_a_range = Money.new(10100, "USD")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range].size).to eq(1)
-        expect(product.errors[:price_in_a_range].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:price_in_a_range].first).to include("must be greater than zero and less than $100")
       end
 
       it "fails validation if linked attribute changed" do
@@ -364,17 +364,17 @@ if defined? ActiveRecord
         product.validates_method_amount = "-12"
         expect(product.valid?).to be_falsey
         expect(product.errors[:validates_method_amount].size).to eq(1)
-        expect(product.errors[:validates_method_amount].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:validates_method_amount].first).to include("must be greater than zero and less than $100")
 
         product.validates_method_amount = Money.new(-1200, "USD")
         expect(product.valid?).to be_falsey
         expect(product.errors[:validates_method_amount].size).to eq(1)
-        expect(product.errors[:validates_method_amount].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:validates_method_amount].first).to include("must be greater than zero and less than $100")
 
         product.validates_method_amount = "0"
         expect(product.valid?).to be_falsey
         expect(product.errors[:validates_method_amount].size).to eq(1)
-        expect(product.errors[:validates_method_amount].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:validates_method_amount].first).to include("must be greater than zero and less than $100")
 
         product.validates_method_amount = "12"
         expect(product.valid?).to be_truthy
@@ -385,24 +385,24 @@ if defined? ActiveRecord
         product.validates_method_amount = "101"
         expect(product.valid?).to be_falsey
         expect(product.errors[:validates_method_amount].size).to eq(1)
-        expect(product.errors[:validates_method_amount].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:validates_method_amount].first).to include("must be greater than zero and less than $100")
 
         product.validates_method_amount = Money.new(10100, "USD")
         expect(product.valid?).to be_falsey
         expect(product.errors[:validates_method_amount].size).to eq(1)
-        expect(product.errors[:validates_method_amount].first).to match(/must be greater than zero and less than \$100/)
+        expect(product.errors[:validates_method_amount].first).to include("must be greater than zero and less than $100")
       end
 
       it "fails validation with the proper error message on the cents field" do
         product.price_in_a_range = "-12"
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range_cents].size).to eq(1)
-        expect(product.errors[:price_in_a_range_cents].first).to match(/greater than 0/)
+        expect(product.errors[:price_in_a_range_cents].first).to include("greater than 0")
 
         product.price_in_a_range = "0"
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range_cents].size).to eq(1)
-        expect(product.errors[:price_in_a_range_cents].first).to match(/greater than 0/)
+        expect(product.errors[:price_in_a_range_cents].first).to include("greater than 0")
 
         product.price_in_a_range = "12"
         expect(product.valid?).to be_truthy
@@ -410,29 +410,29 @@ if defined? ActiveRecord
         product.price_in_a_range = "101"
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range_cents].size).to eq(1)
-        expect(product.errors[:price_in_a_range_cents].first).to match(/less than or equal to 10000/)
+        expect(product.errors[:price_in_a_range_cents].first).to include("less than or equal to 10000")
       end
 
       it "fails validation when a non number string is given" do
         product = Product.create(price_in_a_range: "asd")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range].size).to eq(1)
-        expect(product.errors[:price_in_a_range].first).to match(/greater than zero/)
+        expect(product.errors[:price_in_a_range].first).to include("greater than zero")
 
         product = Product.create(price_in_a_range: "asd23")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price_in_a_range].size).to eq(1)
-        expect(product.errors[:price_in_a_range].first).to match(/greater than zero/)
+        expect(product.errors[:price_in_a_range].first).to include("greater than zero")
 
         product = Product.create(price: "asd")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price].size).to eq(1)
-        expect(product.errors[:price].first).to match(/is not a number/)
+        expect(product.errors[:price].first).to include("is not a number")
 
         product = Product.create(price: "asd23")
         expect(product.valid?).to be_falsey
         expect(product.errors[:price].size).to eq(1)
-        expect(product.errors[:price].first).to match(/is not a number/)
+        expect(product.errors[:price].first).to include("is not a number")
       end
 
       it "passes validation when amount contains spaces (999 999.99)" do


### PR DESCRIPTION
Hello! 

@sunny this PR fixes CI 😳 

First a fix to pin rubocop gems to prevent failures when gems are updated. Pretty similar to https://github.com/RubyMoney/money/pull/1215

Second, rdoc 8 added a hard dependency on rbs >= 4, and rbs 4.x dropped its -java gem so on JRuby it has to compile a C extension, which fails and breaks bundle install before any test runs. rdoc 7.x has no rbs dependency, so pinning it below 8 on JRuby keeps rbs out of the tree entirely. I think we can remove the pin when https://rubygems.org/gems/rbs/versions/4.1.0.pre.2-java is out of prerelease 🤷🏻‍♀️ 