### PR TITLE
Register framework integrations when the gem is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Register the Active Record and Action View integrations when the gem is required, instead of from the railtie initializer
+
 ## 3.0.0
 
 - **Breaking change**: Drop support for Rails < 7.0

--- a/lib/money-rails.rb
+++ b/lib/money-rails.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/lazy_load_hooks"
 require "money"
 require "monetize"
 require "monetize/core_extensions"
@@ -13,6 +14,19 @@ module MoneyRails
   autoload :ActionViewExtension, "money-rails/helpers/action_view_extension"
 
   extend Configuration
+end
+
+# Registering the hooks here, rather than in the railtie initializer, keeps the
+# integration points visible without a full Rails boot. Registration is lazy: the
+# blocks only run once the framework in question is loaded.
+ActiveSupport.on_load(:active_record) do
+  require "money-rails/active_model/validator"
+  require "money-rails/active_record/monetizable"
+  ActiveRecord::Base.include(MoneyRails::ActiveRecord::Monetizable)
+end
+
+ActiveSupport.on_load(:action_view) do
+  ActionView::Base.include MoneyRails::ActionViewExtension
 end
 
 if defined? Rails::Railtie

--- a/lib/money-rails/hooks.rb
+++ b/lib/money-rails/hooks.rb
@@ -5,12 +5,11 @@ module MoneyRails
     PG_ADAPTERS = %w[activerecord-jdbcpostgresql-adapter postgresql postgis].freeze
 
     def self.init
-      # For Active Record
+      # For Active Record migrations
+      #
+      # These stay here, and not in money-rails.rb, because picking the migration
+      # extensions requires a configured database connection.
       ActiveSupport.on_load(:active_record) do
-        require "money-rails/active_model/validator"
-        require "money-rails/active_record/monetizable"
-        ::ActiveRecord::Base.include(MoneyRails::ActiveRecord::Monetizable)
-
         current_adapter = ::ActiveRecord::Base.connection_db_config.configuration_hash[:adapter]
         postgresql_with_money = PG_ADAPTERS.include?(current_adapter)
 
@@ -36,11 +35,6 @@ module MoneyRails
 
       if defined? ::Mongoid
         require "money-rails/mongoid/money"
-      end
-
-      # For ActionView
-      ActiveSupport.on_load(:action_view) do
-        ::ActionView::Base.include MoneyRails::ActionViewExtension
       end
 
       # For ActiveSupport

--- a/spec/money_rails/load_hooks_spec.rb
+++ b/spec/money_rails/load_hooks_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+if defined? ActiveRecord
+  describe MoneyRails do
+    describe "load hooks" do
+      it "monetizes Active Record without a Rails initializer" do
+        script = <<~RUBY
+          require "money-rails"
+          raise "requiring money-rails eagerly loaded Active Record" if defined?(::ActiveRecord)
+
+          require "active_record"
+          raise "monetize is missing" unless ActiveRecord::Base.respond_to?(:monetize)
+        RUBY
+
+        lib_path = File.expand_path("../../lib", __dir__)
+
+        expect(system(RbConfig.ruby, "-I", lib_path, "-e", script)).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Move the two framework mixins — `MoneyRails::ActiveRecord::Monetizable` and `MoneyRails::ActionViewExtension` — from `MoneyRails::Hooks.init` to require time in `lib/money-rails.rb`.

## Why

`Hooks.init` is only called from the railtie initializer, and it is what registers the `ActiveSupport.on_load(:active_record)` / `on_load(:action_view)` blocks. Outside a full Rails boot nothing registers them, so `monetize` ends up defined on no class at all:

```ruby
require "active_record"
require "money-rails"
ActiveRecord::Base.respond_to?(:monetize) # => false
```

That makes the Active Record integration invisible to everything that inspects the code rather than boots a server: doc generators, editor autocomplete, static analysis, and a plain `require "money-rails"` in a script or a test harness. It is the same class of problem as #614 / #727, where `MoneyRails::ActionViewExtension` was unavailable until a callback happened to fire.

Registering an `on_load` hook is lazy and cheap — it does not load Active Record or Action View, it only queues the block until something else loads them. So people using the gem without Rails (#470, #291) pay nothing for the registration, and get `monetize` from the bare `require`.

`require "active_support/lazy_load_hooks"` is added explicitly rather than relying on `money`/`monetize` to have pulled Active Support in; `activesupport` is already a runtime dependency.

## What stays put

The migration extensions stay in `Hooks.init`. Choosing between the PostgreSQL and generic variants reads `connection_db_config`, which needs a configured database — exactly what the railtie's `after: "active_record.initialize_database"` guarantees, and not something a bare `require` can promise.

`Hooks.init` remains public and its README-documented use for non-Rails apps is unchanged. The mixins it no longer performs are already registered by the `require` it necessarily follows, and a repeated `include` of the same module is a no-op regardless.

No behavior change — Rails apps load the same modules into the same classes, in the same order.

## Tested

- `bundle exec rake spec` green on `active_record7.0`, `7.1`, `7.2`, `8.0` and `8.1` (Ruby 4.0), 278 examples each.
- `bundle exec rubocop` clean.
- The new spec shells out to a fresh Ruby that requires `money-rails` *before* `active_record`, asserts the require did not eagerly load Active Record, then asserts `monetize` is there. It fails on `main` and passes here.
- Could not run the Mongoid gemfiles (no local mongod) or the JRuby cell.